### PR TITLE
Fix strict Linux portability issues

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -100,6 +100,8 @@ if(WIN32)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
+    # Use of pthread_condattr_setclock requires a "recent" POSIX setting.
+    add_definitions(-D_POSIX_C_SOURCE=200112)
 endif()
 
 # Clang warns about unused const variables. Generated files may purposely contain unused consts, so silence this warning in Clang

--- a/layers/timeline_semaphore.c
+++ b/layers/timeline_semaphore.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <errno.h>
+#include <time.h>
 
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>

--- a/layers/vk_alloc.h
+++ b/layers/vk_alloc.h
@@ -17,6 +17,8 @@
 #ifndef VK_ALLOC_H_
 #define VK_ALLOC_H_
 
+#include <assert.h>
+#include <string.h>
 #include <vulkan/vulkan.h>
 
 static inline void *vk_alloc(const VkAllocationCallbacks *alloc,

--- a/layers/vk_util.h
+++ b/layers/vk_util.h
@@ -23,6 +23,11 @@
 
 #include "vk_alloc.h"
 
+// "restrict" is a C feature, and C++ compilers may not support it.
+#ifdef __cplusplus
+#define restrict
+#endif
+
 /**
  * @file vk_util.h
  *


### PR DESCRIPTION
- Specify sufficient POSIX_C_SOURCE date to pull in
  pthread_condattr_setclock
- Include time.h, assert.h, string.h as required
- Avoid "restrict" keyword in C++ compilation mode