### PR TITLE
Fix a minor leak issue of semaphore

### DIFF
--- a/layers/timeline_semaphore.c
+++ b/layers/timeline_semaphore.c
@@ -1082,6 +1082,8 @@ static void timeline_DestroySemaphore(
 
     pthread_mutex_unlock(&device->lock);
 
+    object_unmap(&device->semaphores, semaphore);
+
     vk_free2(&device->alloc, pAllocator, semaphore);
 }
 


### PR DESCRIPTION
Semaphore should be unmapped while it's destroyed.

Change-Id: I6981ab86250c46a5a4292577906376416ff6ebd4