### PR TITLE
Fix an issue of timeline_GetPhysicalDeviceProperties2

### DIFF
--- a/layers/timeline_semaphore.c
+++ b/layers/timeline_semaphore.c
@@ -2038,6 +2038,12 @@ static void timeline_GetPhysicalDeviceProperties2(
     if (timeline_properties) {
         timeline_properties->maxTimelineSemaphoreValueDifference = UINT64_MAX;
     }
+
+    VkPhysicalDeviceVulkan12Properties *vulkan12_properties =
+        vk_find_struct(pProperties->pNext, PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES);
+    if (vulkan12_properties) {
+        vulkan12_properties->maxTimelineSemaphoreValueDifference = UINT64_MAX;
+    }
 }
 
 static void timeline_GetPhysicalDeviceExternalSemaphoreProperties(


### PR DESCRIPTION
maxTimelineSemaphoreValueDifference of
VkPhysicalDeviceVulkan12Properties should be set with UINT64_MAX

Change-Id: I06fe5963327f904c9d5fd439cbdac203c750477e