### PR TITLE
Fix VulkanHeaders_INCLUDE_DIRS typo.

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -85,7 +85,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
     endmacro()
 endif()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/generated ${VulkanHeaders_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/generated ${VulkanHeaders_INCLUDE_DIRS})
 
 if(WIN32)
     # Applies to all configurations


### PR DESCRIPTION
See https://github.com/KhronosGroup/Vulkan-ExtensionLayer/blob/6637499182fa76620a8177b47cae871203e481b9/CMakeLists.txt#L44-L55 for where this is defined.

This fixes the build of `VkLayer_khronos_timeline_semaphore` for me with a `Vulkan::Headers` target in my project. Without this change, I see errors about unknown type names (e.g. `VkSemaphoreTypeCreateInfo`), since my (outdated) system `/usr/include/vulkan/vulkan_core.h` is used instead of the in-project `Vulkan-Headers/include/vulkan/vulkan_core.h`.