### PR TITLE
[WIP] Fix layers to load with Explicit Android Layer

### DIFF
--- a/layers/synchronization2.h
+++ b/layers/synchronization2.h
@@ -161,7 +161,6 @@ struct InstanceData {
         DECLARE_HOOK(DestroyInstance);
         DECLARE_HOOK(CreateDevice);
         DECLARE_HOOK(EnumeratePhysicalDevices);
-        DECLARE_HOOK(EnumerateInstanceLayerProperties);
         DECLARE_HOOK(EnumerateDeviceExtensionProperties);
         DECLARE_HOOK(GetPhysicalDeviceFeatures2);
         DECLARE_HOOK(GetPhysicalDeviceFeatures2KHR);


### PR DESCRIPTION
So forgot that Android loader for explicit layers uses the v0 loader-layer interface. The tests should be running with the layer explicitly set but the [Android loader](https://android.googlesource.com/platform/frameworks/native/+/refs/heads/master/vulkan/libvulkan/layers_extensions.cpp#182) needs some functions exposed

There are some random other nit fixes in this as well.

Marked as `WIP` for now as I need to give the loader/layer interface a read-over and go back and see what the proper way to add Android layer support was