### PR TITLE
Add Android Assert support

### DIFF
--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -18,7 +18,6 @@
  * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include <vulkan/vk_layer.h>
-#include <cassert>
 #include <ctype.h>
 #include <cstring>
 #include <iostream>
@@ -28,6 +27,7 @@
 #include <utility>
 #include "synchronization2.h"
 #include "allocator.h"
+#include "log.h"
 #include "vk_format_utils.h"
 #include "vk_layer_config.h"
 #include "vk_safe_struct.h"
@@ -249,7 +249,7 @@ static VkLayerInstanceCreateInfo* GetChainInfo(const VkInstanceCreateInfo* pCrea
     while (chain_info && !(chain_info->sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO && chain_info->function == func)) {
         chain_info = reinterpret_cast<VkLayerInstanceCreateInfo*>(const_cast<void*>(chain_info->pNext));
     }
-    assert(chain_info != NULL);
+    ASSERT(chain_info != NULL);
     return chain_info;
 }
 
@@ -260,7 +260,7 @@ VkResult EnumerateAll(std::vector<T>* vect, std::function<VkResult(uint32_t*, T*
     do {
         uint32_t count = 0;
         result = func(&count, nullptr);
-        assert(result == VK_SUCCESS);
+        ASSERT(result == VK_SUCCESS);
         vect->resize(count);
         result = func(&count, vect->data());
     } while (result == VK_INCOMPLETE);
@@ -270,7 +270,7 @@ VkResult EnumerateAll(std::vector<T>* vect, std::function<VkResult(uint32_t*, T*
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
     VkLayerInstanceCreateInfo* chain_info = GetChainInfo(pCreateInfo, VK_LAYER_LINK_INFO);
 
-    assert(chain_info->u.pLayerInfo);
+    ASSERT(chain_info->u.pLayerInfo);
     auto gpa = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     auto create_instance = reinterpret_cast<PFN_vkCreateInstance>(gpa(NULL, "vkCreateInstance"));
     if (create_instance == NULL) {
@@ -358,7 +358,7 @@ static VkLayerDeviceCreateInfo* GetChainInfo(const VkDeviceCreateInfo* pCreateIn
     while (chain_info && !(chain_info->sType == VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO && chain_info->function == func)) {
         chain_info = reinterpret_cast<VkLayerDeviceCreateInfo*>(const_cast<void*>(chain_info->pNext));
     }
-    assert(chain_info != NULL);
+    ASSERT(chain_info != NULL);
     return chain_info;
 }
 
@@ -439,7 +439,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
 
     VkLayerDeviceCreateInfo* chain_info = GetChainInfo(pCreateInfo, VK_LAYER_LINK_INFO);
 
-    assert(chain_info->u.pLayerInfo);
+    ASSERT(chain_info->u.pLayerInfo);
     PFN_vkGetInstanceProcAddr instance_proc_addr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     PFN_vkCreateDevice create_device = (PFN_vkCreateDevice)instance_proc_addr(instance_data->instance, "vkCreateDevice");
     PFN_vkGetDeviceProcAddr gdpa = chain_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
@@ -837,7 +837,7 @@ DependencyInfoV1::DependencyInfoV1(const DeviceData& device_data, uint32_t info_
             const VkImageMemoryBarrier2KHR& barrier_v2 = info->pImageMemoryBarriers[j];
 
             auto image_data = device_data.image_map.find(barrier_v2.image);
-            assert(image_data != device_data.image_map.end());
+            ASSERT(image_data != device_data.image_map.end());
             ImageAspect aspect = image_data->second.aspect;
 
             src_stage_mask |= ConvertPipelineStageMask(barrier_v2.srcStageMask, kFirst, device_data.features);
@@ -1417,8 +1417,8 @@ extern "C" VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceP
 
 extern "C" VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface* pVersionStruct) {
-    assert(pVersionStruct != nullptr);
-    assert(pVersionStruct->sType == LAYER_NEGOTIATE_INTERFACE_STRUCT);
+    ASSERT(pVersionStruct != nullptr);
+    ASSERT(pVersionStruct->sType == LAYER_NEGOTIATE_INTERFACE_STRUCT);
 
     // Fill in the function pointers if our version is at least capable of having the structure contain them.
     if (pVersionStruct->loaderLayerInterfaceVersion >= 2) {

--- a/utils/log.h
+++ b/utils/log.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2021 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdlib.h>
+
+// Basic Logging Support
+#ifdef __ANDROID__
+#include <android/log.h>
+#define LOG(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VulkanExtensionLayer", __VA_ARGS__))
+#define LOG_FATAL(...)                                                                 \
+    (void)__android_log_print(ANDROID_LOG_FATAL, "VulkanExtensionLayer", __VA_ARGS__); \
+    exit(1);
+#else  // __ANDROID__
+#include <stdio.h>
+#define LOG(...)                  \
+    fprintf(stdout, __VA_ARGS__); \
+    fflush(stdout);
+#endif
+
+// Define own assert because <cassert> on android will not actually assert anything
+#ifdef __ANDROID__
+#define ASSERT(condition)                                                      \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            LOG_FATAL("ASSERT: %s at %s:%d\n", #condition, __FILE__, __LINE__) \
+        }                                                                      \
+    } while (0)
+#else  // __ANDROID__
+#include <cassert>
+#define ASSERT(condition) assert(condition);
+#endif


### PR DESCRIPTION
Still trying to finalize that sync2 works on all Android devices and while debugging I quick added the `utils/log.h` for both ease of using `LOG` but mainly because `assert()` on Android by default will not actually assert and go unoticed

The following message is now being caught on Android

```
F VulkanExtensionLayers: ASSERT: chain_info != NULL at jni/../../layers/synchronization2.cpp:368
```

as to why the `VkCreateDevice` chain be sent from the loader is wrong, still looking into, but wanted to make this a separate PR regardless