### PR TITLE
synchronization2: Query for features used in vkQueueSubmit2KHR

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -105,7 +105,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 
 if(WIN32)
     # Applies to all configurations
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
     add_compile_options("/bigobj")
     # Allow Windows to use multiprocessor compilation


### PR DESCRIPTION
Query for timeline semaphores, device groups and protected memory
before including their structures in the translated submit info.

Change-Id: Ifbd040c3bdeac1f1dff68dd30557f90810e44aea