### PR TITLE
synchronization2: fix layer settings to match layer schema

### DIFF
--- a/layers/json/VkLayer_khronos_synchronization2.json.in
+++ b/layers/json/VkLayer_khronos_synchronization2.json.in
@@ -1,5 +1,5 @@
 {
-    "file_format_version" : "1.2.0",
+    "file_format_version": "1.2.0",
     "layer": {
         "name": "VK_LAYER_KHRONOS_synchronization2",
         "type": "GLOBAL",
@@ -26,15 +26,17 @@
                 ]
             }
         ],
-        "settings": [
-            {
-                "key": "force_enable",
-                "env": "VK_SYNC2_FORCE_ENABLE",
-                "label": "Force Enable",
-                "description": "Force the layer to be active even if the underlying driver already supports the synchonization2 extension.",
-                "type": "BOOL",
-                "default": false
-            }
-        ]
+        "features": {
+            "settings": [
+                {
+                    "key": "force_enable",
+                    "env": "VK_SYNC2_FORCE_ENABLE",
+                    "label": "Force Enable",
+                    "description": "Force the layer to be active even if the underlying driver already supports the synchonization2 extension.",
+                    "type": "BOOL",
+                    "default": false
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
A bug caused old versions of vkconfig to crash when loading the layers settings from the layer repository.
To workaround this issue, the layer schema was modified, this change makes the layer manifest to match the updated layer schema.

This change need to be cherry picked to SDK-1.2.176 branch.