### PR TITLE
manifest: fix url, add introduction

### DIFF
--- a/layers/json/VkLayer_khronos_synchronization2.json.in
+++ b/layers/json/VkLayer_khronos_synchronization2.json.in
@@ -7,7 +7,8 @@
         "api_version": "@VK_VERSION@",
         "implementation_version": "1",
         "description": "Khronos Synchronization2 layer",
-        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/synchronization_usage.html",
+        "introduction": "The VK_LAYER_KHRONOS_synchronization2 extension layer implements the VK_KHR_synchronization2 extension.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/synchronization2_layer.html",
         "status": "STABLE",
         "instance_extensions": [],
         "device_extensions": [


### PR DESCRIPTION
- The URL was pointing the validation layer sync object instead of the layer documentation.
- Add an the 'introduction' field which is use by Vulkan Configurator to describ the layer to the Vulkan developers and within the layer HTML user documentation generated by Vulkan Configurator.