### PR TITLE
sync2: Add handling for swapchain images

### DIFF
--- a/layers/synchronization2.h
+++ b/layers/synchronization2.h
@@ -23,6 +23,7 @@
 #undef VK_NO_PROTOTYPES
 #include <vector>
 #include <memory>
+#include <unordered_set>
 
 #include "allocator.h"
 #include "vk_concurrent_unordered_map.h"
@@ -177,6 +178,11 @@ struct ImageData {
     ImageAspect aspect;
 };
 
+struct SwapchainData {
+    VkFormat format;
+    std::unordered_set<VkImage> images;
+};
+
 struct DeviceFeatures {
     DeviceFeatures(uint32_t api_version, const VkDeviceCreateInfo* create_info);
     DeviceFeatures()
@@ -214,11 +220,15 @@ struct DeviceData {
     bool enable_layer;
     uint32_t api_version;
     vk_concurrent_unordered_map<VkImage, ImageData> image_map;
+    vk_concurrent_unordered_map<VkSwapchainKHR, SwapchainData> swapchain_map;
     struct DeviceDispatchTable {
         DECLARE_HOOK(GetDeviceProcAddr);
         DECLARE_HOOK(DestroyDevice);
         DECLARE_HOOK(CreateImage);
         DECLARE_HOOK(DestroyImage);
+        DECLARE_HOOK(CreateSwapchainKHR);
+        DECLARE_HOOK(GetSwapchainImagesKHR);
+        DECLARE_HOOK(DestroySwapchainKHR);
         DECLARE_HOOK(CmdSetEvent);
         DECLARE_HOOK(CmdResetEvent);
         DECLARE_HOOK(CmdWaitEvents);

--- a/tests/extension_layer_tests.cpp
+++ b/tests/extension_layer_tests.cpp
@@ -241,6 +241,14 @@ bool VkExtensionLayerTest::CheckSynchronization2SupportAndInitState() {
         vk::CreateRenderPass2 =
             reinterpret_cast<PFN_vkCreateRenderPass2>(vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR"));
     }
+    vk::CreateSwapchainKHR =
+            reinterpret_cast<PFN_vkCreateSwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkCreateSwapchainKHR"));
+    vk::GetSwapchainImagesKHR =
+            reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(vk::GetDeviceProcAddr(device(), "vkGetSwapchainImagesKHR"));
+    vk::DestroySwapchainKHR =
+            reinterpret_cast<PFN_vkDestroySwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkDestroySwapchainKHR"));
+    vk::AcquireNextImageKHR=
+            reinterpret_cast<PFN_vkAcquireNextImageKHR>(vk::GetDeviceProcAddr(device(), "vkAcquireNextImageKHR"));
 
     return true;
 }

--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -32,9 +32,11 @@
 void Sync2Test::SetUp() {
     VkExtensionLayerTest::SetUp();
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    VkExtensionLayerTest::AddSurfaceInstanceExtension();
     instance_layers_.push_back("VK_LAYER_KHRONOS_synchronization2");
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
+    VkExtensionLayerTest::AddSwapchainDeviceExtension();
     if (!CheckSynchronization2SupportAndInitState()) {
         GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
     }
@@ -1334,4 +1336,110 @@ TEST_F(Sync2CompatTest, Vulkan10) {
     vk::DestroyDevice(device, NULL);
 
     vk::DestroyInstance(instance, NULL);
+}
+
+TEST_F(Sync2Test, SwapchainImage) {
+    if (!InitSwapchain()) {
+        printf("%s Cannot create surface or swapchain, skipping CmdCopySwapchainImage test\n", kSkipPrefix);
+        return;
+    }
+    uint32_t image_index, image_count;
+    vk::GetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, NULL);
+    std::vector<VkImage> swapchain_images(image_count);
+    vk::GetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, swapchain_images.data());
+    VkFenceCreateInfo fenceci = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
+    VkFence fence;
+    VkResult ret = vk::CreateFence(m_device->device(), &fenceci, nullptr, &fence);
+    ASSERT_VK_SUCCESS(ret);
+    ret = vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, fence, &image_index);
+    ASSERT_VK_SUCCESS(ret);
+    VkAttachmentDescription attach[] = {
+        {0, VK_FORMAT_B8G8R8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+         VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
+         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
+    };
+    VkAttachmentReference att_ref = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+
+    VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &att_ref, nullptr, nullptr, 0, nullptr};
+    VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attach, 1, &subpass, 0, nullptr};
+    VkRenderPass rp1, rp2;
+
+    ret = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp1);
+    ASSERT_VK_SUCCESS(ret);
+    attach[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    ret = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp2);
+    VkImageViewCreateInfo ivci = {
+        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        nullptr,
+        0,
+        swapchain_images[image_index],
+        VK_IMAGE_VIEW_TYPE_2D,
+        VK_FORMAT_B8G8R8A8_UNORM,
+        {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+         VK_COMPONENT_SWIZZLE_IDENTITY},
+        {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    VkImageView view;
+    ret = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
+    ASSERT_VK_SUCCESS(ret);
+    VkFramebufferCreateInfo fci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp1, 1, &view, 32, 32, 1};
+    VkFramebuffer fb1, fb2;
+    ret = vk::CreateFramebuffer(m_device->device(), &fci, nullptr, &fb1);
+    fci.renderPass = rp2;
+    ret = vk::CreateFramebuffer(m_device->device(), &fci, nullptr, &fb2);
+    ASSERT_VK_SUCCESS(ret);
+    VkRenderPassBeginInfo rpbi = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, nullptr, rp1, fb1, {{0, 0}, {32, 32}}, 0, nullptr};
+    m_commandBuffer->begin();
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdEndRenderPass(m_commandBuffer->handle());
+    rpbi.framebuffer = fb2;
+    rpbi.renderPass = rp2;
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdEndRenderPass(m_commandBuffer->handle());
+
+    VkImageMemoryBarrier2KHR img_barrier = {};
+    img_barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    img_barrier.srcAccessMask = 0;
+    img_barrier.dstAccessMask = 0;
+    img_barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+    img_barrier.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;;
+    img_barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    img_barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    img_barrier.image = swapchain_images[image_index];
+    img_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    img_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    img_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    img_barrier.subresourceRange.baseArrayLayer = 0;
+    img_barrier.subresourceRange.baseMipLevel = 0;
+    img_barrier.subresourceRange.layerCount = 1;
+    img_barrier.subresourceRange.levelCount = 1;
+
+    VkDependencyInfoKHR info = {};
+    info.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR;
+    info.imageMemoryBarrierCount = 1;
+    info.pImageMemoryBarriers = &img_barrier;
+    vk::CmdPipelineBarrier2KHR(m_commandBuffer->handle(), &info);
+    m_commandBuffer->end();
+
+    vk::QueueSubmit2KHR(m_commandBuffer->Queue()->handle(), 0, nullptr, fence);
+
+    VkCommandBufferSubmitInfoKHR cb_info = {};
+    cb_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO_KHR;
+    cb_info.commandBuffer = m_commandBuffer->handle();
+
+    VkSubmitInfo2KHR submit_info = {};
+    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2_KHR;
+    submit_info.commandBufferInfoCount = 1;
+    submit_info.pCommandBufferInfos = &cb_info;
+    vk::QueueSubmit2KHR(m_commandBuffer->Queue()->handle(), 1, &submit_info, VK_NULL_HANDLE);
+    ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_commandBuffer->Queue()->handle()));
+    m_errorMonitor->ExpectSuccess();
+
+    vk::DestroyFramebuffer(m_device->device(), fb1, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp1, NULL);
+    vk::DestroyFramebuffer(m_device->device(), fb2, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp2, NULL);
+    vk::DestroyFence(m_device->device(), fence, NULL);
+    vk::DestroyImageView(m_device->device(), view, NULL);
+    DestroySwapchain();
 }


### PR DESCRIPTION
Hook vkGetSwapchainImagesKHR() and related functions so that we can track state for swapchain images.

Fixes #90 