### PR TITLE
ci: Remove windows-2016 github actions runner

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Valve Corporation
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021-2022 Valve Corporation
+# Copyright (c) 2021-2022 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ jobs:
       matrix:
         arch: [ x64, Win32 ]
         config: [ debug, release ]
-        os: [ windows-2016, windows-2019 ]
+        os: [ windows-latest ]
         exclude:
           - arch: Win32
             config: release


### PR DESCRIPTION
It is no longer supported.