### PR TITLE
Build `VK_LAYER_KHRONOS_timeline_semaphore` for Android

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -52,6 +52,18 @@ LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := VkLayer_khronos_timeline_semaphore
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/timeline_semaphore.c \
+                   $(SRC_DIR)/layers/hash_table.cpp
+LOCAL_C_INCLUDES += $(VULKAN_INCLUDE)
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -Wno-cast-calling-convention -fexceptions
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
+LOCAL_LDLIBS    := -llog -landroid
+LOCAL_LDFLAGS   += -Wl,-Bsymbolic
+LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := VkExtensionLayerTests
 LOCAL_SRC_FILES += $(SRC_DIR)/tests/extension_layer_tests.cpp \
                    $(SRC_DIR)/tests/vktestbinding.cpp \


### PR DESCRIPTION
When building for Android, binaries are produced for `VK_LAYER_KHRONOS_synchronization2`, but not for `VK_LAYER_KHRONOS_timeline_semaphore`.

This PR modifies `build-android/jni/Android.mk` to add LOCAL_MODULE `VkLayer_khronos_timeline_semaphore` so that the binaries for `VK_LAYER_KHRONOS_timeline_semaphore` are built.

The layer has been tested to work on my Galaxy S20 Ultra with Adreno 650, Qualcomm driver version `512.444.0`, which doesn't natively support `VK_KHR_timeline_semaphore`.

Fixes issue #117.