### PR TITLE
scripts: use current Python executable when running command lines

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -16,7 +16,7 @@
       "install_dir" : "glslang/build/install",
       "commit" : "5755de46b07e4374c05fb1081f65f7ae1f8cca81",
       "prebuild" : [
-        "python update_glslang_sources.py"
+        "{python} update_glslang_sources.py"
       ],
       "cmake_options" : [
         "-DUSE_CCACHE=ON"


### PR DESCRIPTION
Some of the "prebuild" command lines require execution of Python; but running the "python" command doesn't work on some systems (e.g. Linux systems that use "python" to mean Python 2 and "python3" to refer to Python 3, that don't happen to have Python 2 installed), and can cause the invocation of an unknown Python in any case (e.g. if a script is started with Python3.7, but there's also an installed Python2, the "wrong" Python may be invoked).

This fix allows a syntax, "{python}", that can be used for command strings in known_good.json.  The command strings are formatted to replace "{python}" with a value dependent on the system runtime, and then are split via shlex.split() and invoked.

update_deps.py:
- define a split_command() function that both formats and splits a command line
- use split_command() instead of shlex.split()

known_good.json:
- glslang prebuild "python update_glslang_sources.py" replaced with "{python} update_glslang_sources.py"