### PR TITLE
Fix Issues detected with Address Sanitizer

### DIFF
--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -435,7 +435,7 @@ DeviceFeatures::DeviceFeatures(uint32_t api_version, const VkDeviceCreateInfo* c
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV: {
                 auto mesh_shader = reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(chain);
                 meshShader = 0 != mesh_shader->meshShader;
-                taskShader = 0 != mesh_shader->taskShader;;
+                taskShader = 0 != mesh_shader->taskShader;
             } break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV: {
                 auto shading_rate = reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(chain);
@@ -472,13 +472,13 @@ static void RemoveExtensionString(char** string_array, uint32_t* size, const cha
 }
 
 // this code depends on the allocation behavior of SafePnextCopy() in vk_safe_struct.cpp
-static void RemoveDeviceFeature(safe_VkDeviceCreateInfo* create_info, uint32_t s_type) {
+static void RemoveSynchronization2FeaturesKHR(safe_VkDeviceCreateInfo* create_info) {
     auto cur = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     auto prev_ptr = const_cast<VkBaseInStructure**>(reinterpret_cast<const VkBaseInStructure**>(&create_info->pNext));
     while (cur != nullptr) {
-        if (cur->sType == s_type) {
+        if (cur->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR) {
             *prev_ptr = const_cast<VkBaseInStructure*>(cur->pNext);
-            delete cur;
+            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2FeaturesKHR*>(cur);
             break;
         }
         prev_ptr = const_cast<VkBaseInStructure**>(&cur->pNext);
@@ -520,7 +520,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
             RemoveExtensionString(const_cast<char**>(create_info.ppEnabledExtensionNames), &create_info.enabledExtensionCount,
                                   VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
 
-            RemoveDeviceFeature(&create_info, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR);
+            RemoveSynchronization2FeaturesKHR(&create_info);
 
             result = create_device(physicalDevice, create_info.ptr(), pAllocator, pDevice);
         } else {

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -322,7 +322,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
     auto instance_data = GetInstanceData(instance);
     VkResult result =
         instance_data->vtable.EnumeratePhysicalDevices(instance_data->instance, pPhysicalDeviceCount, pPhysicalDevices);
-    if (result == VK_SUCCESS && pPhysicalDevices != nullptr) {
+    if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pPhysicalDevices != nullptr) {
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
             VkPhysicalDeviceProperties properties{};
             auto physical_device = pPhysicalDevices[i];

--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1181,12 +1181,10 @@ TEST_F(Sync2CompatTest, Vulkan10) {
     ASSERT_VK_SUCCESS(vk::CreateInstance(&inst_info, NULL, &instance));
 
     uint32_t gpu_count = 0;
-    VkPhysicalDevice *gpus = NULL;
-
     ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance, &gpu_count, NULL));
 
-    gpus = new VkPhysicalDevice[gpu_count];
-    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance, &gpu_count, gpus));
+    std::vector<VkPhysicalDevice> gpus{gpu_count};
+    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance, &gpu_count, gpus.data()));
 
     const float priority = 1.0f;
 
@@ -1196,13 +1194,10 @@ TEST_F(Sync2CompatTest, Vulkan10) {
     queue_info.pQueuePriorities = &priority;
 
     uint32_t queue_count = 0;
-    VkQueueFamilyProperties *queue_props = NULL;
     vk::GetPhysicalDeviceQueueFamilyProperties(gpus[0], &queue_count, NULL);
+    std::vector<VkQueueFamilyProperties> queue_props{queue_count};
     ASSERT_NE(queue_count, 0);
-
-    queue_props = new VkQueueFamilyProperties[queue_count];
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpus[0], &queue_count, NULL);
-    (void)queue_props;
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpus[0], &queue_count, queue_props.data());
 
     queue_info.flags = 0;
     queue_info.queueFamilyIndex = 0;
@@ -1342,7 +1337,7 @@ TEST_F(Sync2Test, SwapchainImage) {
     img_barrier.srcAccessMask = 0;
     img_barrier.dstAccessMask = 0;
     img_barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    img_barrier.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;;
+    img_barrier.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     img_barrier.image = swapchain_images[image_index];


### PR DESCRIPTION
1. Previously, the Sync2 layer would delete the Sync2FeaturesKHR struct
as if it was a VkBaseInObject, which woudld trigger memory checkers due
to deleting an object of a smaller size than what was initialized.

2. If the application didn't provide enough space for all of the physical
devices enumerated, this would cause the Sync2 layer to just not initialize
its internal list of physical devices, leading to subsequent crashes.

3. Tests were using raw new which would leak the objects.