### PR TITLE
scripts: Remove the need to set PYTHONPATH everywhere

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -38,7 +38,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - name: Set PYTHONPATH
-        run: echo "PYTHONPATH=$GITHUB_WORKSPACE/external/${{ matrix.config }}/Vulkan-Headers/registry:$PYTHONPATH" >> $GITHUB_ENV
       - name: Build ExtensionLayer
         run: python3 scripts/github_ci_android.py --abi ${{ matrix.abi }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -63,8 +63,6 @@ jobs:
       - uses: lukka/get-cmake@latest
         with:
           cmakeVersion: 3.17.2
-      - name: Set PYTHONPATH
-        run: echo "PYTHONPATH=$GITHUB_WORKSPACE/external/Vulkan-Headers/registry:$PYTHONPATH" >> $GITHUB_ENV
       - name: Install build dependencies
         run: |
           python3 -m pip install jsonschema pyparsing

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -49,8 +49,6 @@ jobs:
           winsdk-build-version: 17763
       - name: Install build dependencies
         run: python3 -m pip install jsonschema pyparsing
-      - name: Set PYTHONPATH
-        run: echo "PYTHONPATH=$env:GITHUB_WORKSPACE\\external\\${{ matrix.config }}\\Vulkan-Headers\\registry;$env:PYTHONPATH" >> $env:GITHUB_ENV
       - name: Build Vulkan-ExtensionLayer
         run: python3 scripts/github_ci_build_desktop.py --config ${{ matrix.config }} --arch ${{ matrix.arch }}
         if: matrix.os != 'windows-2016'

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -26,7 +26,6 @@ import tempfile
 import difflib
 import json
 
-import common_codegen
 
 # files to exclude from --verify check
 verify_exclude = ['.clang-format']
@@ -39,6 +38,10 @@ def main(argv):
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
     args = parser.parse_args(argv)
+
+    # We need modules from the registry directory, add it here so no one has to set it in PYTHONPATH
+    sys.path.insert(0, args.registry)
+    import common_codegen
 
     gen_cmds = [*[[common_codegen.repo_relative('scripts/lvl_genvk.py'),
                    '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),


### PR DESCRIPTION
The scripts all need to know the registry directory already, so they can update sys.path to include it.