### PR TITLE
 tests: Set VK_SYNC2_FORCE_ENABLE when running sync2 tests

### DIFF
--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -92,9 +92,9 @@ static void string_tolower(std::string &s) {
 
 static bool GetForceEnable() {
     bool result = false;
-    std::string setting = GetLayerEnvVar(kEnvarForceEnable);
+    std::string setting = GetEnvironment(kEnvarForceEnable);
     if (setting.empty()) {
-        setting = getLayerOption(kLayerSettingsForceEnable);
+        setting = GetLayerOption(kLayerSettingsForceEnable);
     }
     if (!setting.empty()) {
         string_tolower(setting);

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -77,9 +77,9 @@ static void string_tolower(std::string &s) {
 
 static bool GetForceEnable() {
     bool result = false;
-    std::string setting = GetLayerEnvVar(kEnvarForceEnable);
+    std::string setting = GetEnvironment(kEnvarForceEnable);
     if (setting.empty()) {
-        setting = getLayerOption(kLayerSettingsForceEnable);
+        setting = GetLayerOption(kLayerSettingsForceEnable);
     }
     if (!setting.empty()) {
         string_tolower(setting);
@@ -153,8 +153,8 @@ static void SetupCustomStypes() {
 #else
         ":";
 #endif
-    SetCustomStypeInfo(getLayerOption(kLayerSettingsCustomStypeList), ",");
-    SetCustomStypeInfo(GetLayerEnvVar(kEnvarCustomStypeList), kEnvDelim);
+    SetCustomStypeInfo(GetLayerOption(kLayerSettingsCustomStypeList), ",");
+    SetCustomStypeInfo(GetEnvironment(kEnvarCustomStypeList), kEnvDelim);
 }
 
 uintptr_t DispatchKey(const void* object) {

--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -28,8 +28,10 @@
 
 #include "extension_layer_tests.h"
 #include "synchronization2_tests.h"
+#include "vk_layer_config.h"
 
 void Sync2Test::SetUp() {
+    SetEnvironment("VK_SYNC2_FORCE_ENABLE", "1");
     VkExtensionLayerTest::SetUp();
     SetTargetApiVersion(VK_API_VERSION_1_2);
     VkExtensionLayerTest::AddSurfaceInstanceExtension();

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ class VkImageObj;
 #include <unordered_map>
 #include <unordered_set>
 
+#include "vk_layer_config.h"
+
 using vk_testing::MakeVkHandles;
 
 template <class Dst, class Src>
@@ -80,14 +82,6 @@ class VkDeviceObj : public vk_testing::Device {
 
     VkQueue m_queue;
 };
-
-typedef enum {
-    kInformationBit = VK_DEBUG_REPORT_INFORMATION_BIT_EXT,
-    kWarningBit = VK_DEBUG_REPORT_WARNING_BIT_EXT,
-    kPerformanceWarningBit = VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-    kErrorBit = VK_DEBUG_REPORT_ERROR_BIT_EXT,
-    kDebugBit = VK_DEBUG_REPORT_DEBUG_BIT_EXT,
-} LogMessageTypeBits;
 
 // ErrorMonitor Usage:
 //

--- a/utils/vk_layer_config.h
+++ b/utils/vk_layer_config.h
@@ -33,10 +33,6 @@
 #define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
     kVkConfig,
     kEnvVar,
@@ -92,18 +88,20 @@ const std::unordered_map<std::string, VkFlags> log_msg_type_option_definitions =
                                                                                   {std::string("error"), kErrorBit},
                                                                                   {std::string("debug"), kDebugBit}};
 
-const char *getLayerOption(const char *option);
-const char *GetLayerEnvVar(const char *option);
+const char *GetLayerOption(const char *option);
+void SetLayerOption(const char *option, const char *val);
+
+// Get an environment variable, returns "" if the variable is unset.
+std::string GetEnvironment(const char *name);
+
+// Set an environment variable, if it is not already set
+bool SetEnvironment(const char *name, const char *value);
+
 const SettingsFileInfo *GetLayerSettingsFileInfo();
 
-FILE *getLayerLogOutput(const char *option, const char *layer_name);
+FILE *GetLayerLogOutput(const char *option, const char *layer_name);
 VkFlags GetLayerOptionFlags(std::string option, std::unordered_map<std::string, VkFlags> const &enum_data, uint32_t option_default);
 
-void setLayerOption(const char *option, const char *val);
 void PrintMessageFlags(VkFlags vk_flags, char *msg_flags);
 void PrintMessageSeverity(VkFlags vk_flags, char *msg_flags);
 void PrintMessageType(VkFlags vk_flags, char *msg_flags);
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
Make sure we're testing the layer and not the underlying driver by default.

The new SetEnvironment() does not overwrite existing values, so if you REALLY want to test the driver just set `VK_SYNC2_FORCE_ENABLE=0` before running the tests.