### PR TITLE
build-android: No need to build shaderc

### DIFF
--- a/build-android/update_external_sources_android.bat
+++ b/build-android/update_external_sources_android.bat
@@ -1,10 +1,10 @@
 @echo off
-REM Update source for glslang, spirv-tools, and shaderc
+REM Update source for glslang and spirv-tools
 
 REM
 REM Copyright 2016 The Android Open Source Project
-REM Copyright (C) 2015 Valve Corporation
-REM Copyright 2018 LunarG, Inc.
+REM Copyright (C) 2015,2023 Valve Corporation
+REM Copyright 2018,2023 LunarG, Inc.
 REM
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ set errorCode=0
 set ANDROID_BUILD_DIR=%~dp0
 set BUILD_DIR=%ANDROID_BUILD_DIR%
 set BASE_DIR=%BUILD_DIR%\third_party
-set SHADERC_DIR=%BASE_DIR%\shaderc
 
 for %%X in (where.exe) do (set FOUND=%%~$PATH:X)
 if not defined FOUND (
@@ -56,19 +55,12 @@ if %ERRORLEVEL% equ 1 (
 
 if %errorCode% neq 0 (goto:error)
 
-echo Creating and/or updating glslang, spirv-tools, spirv-headers, shaderc, vulkan-headers, vulkan-tools in %BASE_DIR%
-
-set build-shaderc=1
+echo Creating and/or updating glslang, spirv-tools, spirv-headers, vulkan-headers, vulkan-tools in %BASE_DIR%
 
 REM Pull down or update external dependencies
 echo Update external dependencies based on the %ANDROID_BUILD_DIR%/known_good.json file
 py -3 ../scripts/update_deps.py --no-build --dir %BASE_DIR% --known_good_dir %BUILD_DIR%
 
-
-if %build-shaderc% equ 1 (
-   call:build_shaderc
-   if %errorCode% neq 0 (goto:error)
-)
 
 echo.
 echo Exiting
@@ -84,22 +76,7 @@ if not "%cd%\" == "%BUILD_DIR%" ( cd %BUILD_DIR% )
 endlocal
 REM This needs a fix to return error, something like exit %errorCode%
 REM Right now it is returning 0
-goto:eof
 
 
 
-REM // ======== Functions ======== //
 
-:build_shaderc
-   echo.
-   echo Building %SHADERC_DIR%
-   cd %SHADERC_DIR%\android_test
-   echo Building shaderc with Android NDK
-   call ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party -j 4
-   REM Check for existence of one lib, even though we should check for all results
-   if not exist %SHADERC_DIR%\android_test\obj\local\x86\libshaderc.a (
-      echo.
-      echo shaderc build failed!
-      set errorCode=1
-   )
-goto:eof

--- a/build-android/update_external_sources_android.sh
+++ b/build-android/update_external_sources_android.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Update source for glslang, spirv-tools, shaderc
+# Update source for glslang and spirv-tools
 
 # Copyright 2016 The Android Open Source Project
-# Copyright (C) 2015 Valve Corporation
+# Copyright (C) 2015,2023 Valve Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,24 +77,9 @@ then
     echo Skipping build.
 fi
 
-function build_shaderc () {
-   echo "Building $BASEDIR/shaderc"
-   cd $BASEDIR/shaderc/android_test
-   if [[ $abi ]]; then
-      ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party APP_ABI=$abi -j $cores;
-   else
-      ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party -j $cores;
-   fi
-}
-
 # Pull down or update external dependencies
 echo "Update external dependencies based on the $ANDROIDBUILDDIR/known_good.json file"
 python3 ../scripts/update_deps.py --no-build --dir $BASEDIR --known_good_dir $BUILDDIR
-
-if [[ -z $nobuild ]]
-then
-build_shaderc
-fi
 
 echo ""
 echo "${0##*/} finished."


### PR DESCRIPTION
It is included in recent NDKs and there's no reason to try to build it ourselves.

Fixes #208