### PR TITLE
shaderObject: Fix viewport and scissor count

### DIFF
--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -1597,8 +1597,8 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
 
     VkPipelineViewportStateCreateInfo viewport_state{};
     viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    viewport_state.viewportCount = state->GetNumViewports();
-    viewport_state.scissorCount = state->GetNumScissors();
+    viewport_state.viewportCount = cmd_data.device_data->HasDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) ? 0u : state->GetNumViewports();
+    viewport_state.scissorCount = cmd_data.device_data->HasDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT) ? 0u : state->GetNumScissors();
     VkPipelineViewportDepthClipControlCreateInfoEXT depth_clip_control_state{
         VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT,
         nullptr,


### PR DESCRIPTION
viewportCount must be 0 if VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT is used and scissorCount must be 0 if VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT is used