### PR TITLE
shader_object: restore 32-bit build

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -89,11 +89,6 @@ if (WIN32)
     list(REMOVE_ITEM TARGET_NAMES "VkLayer_khronos_timeline_semaphore")
 endif()
 
-# The Vulkan SDK has deliberately chosen not to ship 32-bit VkLayer_khronos_shader_object files
-if (CMAKE_SIZEOF_VOID_P EQUAL "4")
-    list(REMOVE_ITEM TARGET_NAMES "VkLayer_khronos_shader_object")
-endif()
-
 # There are currently no plans to ship Memory Compression part of the Vulkan SDK
 list(REMOVE_ITEM TARGET_NAMES "VkLayer_khronos_memory_decompression")
 


### PR DESCRIPTION
The decision to only ship 64-bit VkLayer_khronos_shader_object (commit bd02fcde74f17695b846e4700327976815493686) has been reversed.

This change restores the 32-bit build, essentially reverting the above commit (which couldn't be simply reverted due to unrelated conflicting changes to layers/CMakeLists.txt).