### PR TITLE
tests: Fix crashes when the layer under test isn't found

### DIFF
--- a/tests/decompression_tests.cpp
+++ b/tests/decompression_tests.cpp
@@ -32,9 +32,6 @@ void DecompressionTest::SetUp() {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     VkExtensionLayerTest::AddSwapchainDeviceExtension();
-    if (!CheckDecompressionSupportAndInitState()) {
-        GTEST_SKIP() << kSkipPrefix << " decompression not supported, skipping test";
-    }
 }
 
 void DecompressionTest::TearDown() {}
@@ -43,6 +40,9 @@ TEST_F(DecompressionTest, DecompressMemory) {
     TEST_DESCRIPTION("Test vkCmdDecompressMemoryNV.");
     VkResult result = VK_SUCCESS;
 
+    if (!CheckDecompressionSupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " decompression not supported, skipping test";
+    }
     VkConstantBufferObj srcBuffer1(m_device, COMPRESSED_SIZE1, compressedData1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     ASSERT_TRUE(srcBuffer1.initialized());
 
@@ -116,6 +116,9 @@ TEST_F(DecompressionTest, DecompressMemory) {
 TEST_F(DecompressionTest, DecompressMemoryIndirect) {
     TEST_DESCRIPTION("Test vkCmdDecompressMemoryIndirectCountNV.");
 
+    if (!CheckDecompressionSupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " decompression not supported, skipping test";
+    }
     VkResult result = VK_SUCCESS;
 
     VkConstantBufferObj srcBuffer1(m_device, COMPRESSED_SIZE1, compressedData1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);

--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -39,9 +39,6 @@ void Sync2Test::SetUp() {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     VkExtensionLayerTest::AddSwapchainDeviceExtension();
-    if (!CheckSynchronization2SupportAndInitState()) {
-        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
-    }
 }
 
 void Sync2Test::TearDown() {}
@@ -106,6 +103,9 @@ void Sync2Test::ValidOwnershipTransfer(ErrorMonitor *monitor, VkCommandBufferObj
 
 TEST_F(Sync2Test, OwnershipTranfersImage) {
     TEST_DESCRIPTION("Valid image ownership transfers that shouldn't create errors");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
     if (no_gfx == UINT32_MAX) {
@@ -157,6 +157,9 @@ TEST_F(Sync2Test, OwnershipTranfersImage) {
 
 TEST_F(Sync2Test, OwnershipTranfersBuffer) {
     TEST_DESCRIPTION("Valid buffer ownership transfers that shouldn't create errors");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
     if (no_gfx == UINT32_MAX) {
@@ -211,6 +214,9 @@ TEST_F(Sync2Test, OwnershipTranfersBuffer) {
 
 TEST_F(Sync2Test, SecondaryCommandBufferBarrier) {
     TEST_DESCRIPTION("Add a pipeline barrier in a secondary command buffer");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     m_errorMonitor->ExpectSuccess();
 
@@ -384,6 +390,10 @@ TEST_F(Sync2Test, SecondaryCommandBufferBarrier) {
 
 TEST_F(Sync2Test, SecondaryCommandBufferImageLayoutTransitions) {
     TEST_DESCRIPTION("Perform an image layout transition in a secondary command buffer followed by a transition in the primary.");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
+
     VkResult err;
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
     if (!depth_format) {
@@ -491,6 +501,9 @@ TEST_F(Sync2Test, SecondaryCommandBufferImageLayoutTransitions) {
 
 TEST_F(Sync2Test, QueueSubmitSemaphoresAndLayoutTracking) {
     TEST_DESCRIPTION("Submit multiple command buffers with chained semaphore signals and layout transitions");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     m_errorMonitor->ExpectSuccess();
     VkCommandBuffer cmd_bufs[4];
@@ -599,6 +612,9 @@ TEST_F(Sync2Test, QueueSubmitSemaphoresAndLayoutTracking) {
 }
 
 TEST_F(Sync2Test, CommandBufferSimultaneousUseSync) {
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
     m_errorMonitor->ExpectSuccess();
     VkResult err;
 
@@ -661,6 +677,9 @@ TEST_F(Sync2Test, CommandBufferSimultaneousUseSync) {
 
 TEST_F(Sync2Test, BarrierLayoutToImageUsage) {
     TEST_DESCRIPTION("Ensure barriers' new and old VkImageLayout are compatible with their images' VkImageUsageFlags");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
     m_errorMonitor->ExpectSuccess();
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
@@ -761,6 +780,9 @@ TEST_F(Sync2Test, BarrierLayoutToImageUsage) {
 
 TEST_F(Sync2Test, WaitEventThenSet) {
     TEST_DESCRIPTION("Wait on a event then set it after the wait has been submitted.");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     m_errorMonitor->ExpectSuccess();
 
@@ -828,6 +850,9 @@ TEST_F(Sync2Test, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenceTwoWFF) {
     TEST_DESCRIPTION(
         "Two command buffers, each in a separate QueueSubmit call submitted on separate queues, the second having a fence followed "
         "by two consecutive WaitForFences calls on the same fence.");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     if ((m_device->queue_props.empty()) || (m_device->queue_props[0].queueCount < 2)) {
         GTEST_SKIP() << kSkipPrefix << "  Queue family needs to have multiple queues to run this test." << std::endl;
@@ -943,6 +968,9 @@ TEST_F(Sync2Test, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenceTwoWFF) {
 TEST_F(Sync2Test, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) {
     TEST_DESCRIPTION(
         "Two command buffers each in a separate SubmitInfo sent in a single QueueSubmit call followed by a WaitForFences call.");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     m_errorMonitor->ExpectSuccess();
 
@@ -1042,6 +1070,9 @@ TEST_F(Sync2Test, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) {
 
 TEST_F(Sync2Test, ClearDepthStencilWithValidRange) {
     TEST_DESCRIPTION("Record clear depth with a valid VkImageSubresourceRange");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -1084,6 +1115,9 @@ TEST_F(Sync2Test, ClearDepthStencilWithValidRange) {
 
 TEST_F(Sync2Test, QueueSubmitTimelineSemaphore) {
     TEST_DESCRIPTION("Submit a queue with a timeline semaphore.");
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
 
     auto timeline_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&timeline_features);
@@ -1258,6 +1292,9 @@ TEST_F(Sync2CompatTest, Vulkan10) {
 }
 
 TEST_F(Sync2Test, SwapchainImage) {
+    if (!CheckSynchronization2SupportAndInitState()) {
+        GTEST_SKIP() << kSkipPrefix << " synchronization2 not supported, skipping test";
+    }
     if (!InitSwapchain()) {
         printf("%s Cannot create surface or swapchain, skipping CmdCopySwapchainImage test\n", kSkipPrefix);
         return;


### PR DESCRIPTION
It looks like calling GTEST_SKIP() inside of SetUp() methods doesn't actually skip the test body, even though the documentation says it does. Move some of the init code to the test bodies to work around this.