### PR TITLE
Make tests use VK_LAYER_PATH by default

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,20 @@
 # limitations under the License.
 # ~~~
 
+# run the generator expression on the test_layer_location file
+file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/test_layer_location_$<CONFIG>.h" INPUT "${CMAKE_CURRENT_LIST_DIR}/generator_source/test_layer_location.h")
+
+# copy $<BUILD>/test_layer_location_$<CONFIG> to $<BUILD>/test_layer_location.h
+add_custom_command(
+    PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_BINARY_DIR}/test_layer_location_$<CONFIG>.h" "${CMAKE_BINARY_DIR}/test_layer_location.h"
+    VERBATIM
+    DEPENDS  "${CMAKE_BINARY_DIR}/test_layer_location_$<CONFIG>.h"
+    OUTPUT   "${CMAKE_BINARY_DIR}/test_layer_location.h"
+    COMMENT  "creating test_layer_location.h file ({event: PRE_BUILD}, {filename: test_layer_location.h })"
+    )
+add_custom_target (generate_test_layer_location DEPENDS "${CMAKE_BINARY_DIR}/test_layer_location.h")
+
 # Needed to make structure definitions match with glslang libraries
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
@@ -72,7 +86,8 @@ if(MSVC_IDE)
     set_target_properties(vk_extension_layer_tests PROPERTIES VS_DEBUGGER_ENVIRONMENT "VK_LAYER_PATH=$<TARGET_FILE_DIR:VkLayer_khronos_synchronization2>")
 endif()
 
-add_dependencies(vk_extension_layer_tests VkLayer_khronos_synchronization2 VkLayer_khronos_memory_decompression)
+add_dependencies(vk_extension_layer_tests VkLayer_khronos_synchronization2 VkLayer_khronos_memory_decompression generate_test_layer_location)
+
 # Note that there is no need to add GTEST directories here due to googletest exporting them via the gtest target.
 target_include_directories(vk_extension_layer_tests
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/extension_layer_tests.cpp
+++ b/tests/extension_layer_tests.cpp
@@ -28,6 +28,10 @@
 #include "extension_layer_tests.h"
 #include "vk_typemap_helper.h"
 
+#if !defined(ANDROID)
+#include "test_layer_location.h"
+#endif
+
 // Global list of sType,size identifiers
 std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
 
@@ -288,14 +292,11 @@ bool VkExtensionLayerTest::CheckSynchronization2SupportAndInitState() {
         vk::CreateRenderPass2 =
             reinterpret_cast<PFN_vkCreateRenderPass2>(vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR"));
     }
-    vk::CreateSwapchainKHR =
-            reinterpret_cast<PFN_vkCreateSwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkCreateSwapchainKHR"));
+    vk::CreateSwapchainKHR = reinterpret_cast<PFN_vkCreateSwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkCreateSwapchainKHR"));
     vk::GetSwapchainImagesKHR =
-            reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(vk::GetDeviceProcAddr(device(), "vkGetSwapchainImagesKHR"));
-    vk::DestroySwapchainKHR =
-            reinterpret_cast<PFN_vkDestroySwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkDestroySwapchainKHR"));
-    vk::AcquireNextImageKHR=
-            reinterpret_cast<PFN_vkAcquireNextImageKHR>(vk::GetDeviceProcAddr(device(), "vkAcquireNextImageKHR"));
+        reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(vk::GetDeviceProcAddr(device(), "vkGetSwapchainImagesKHR"));
+    vk::DestroySwapchainKHR = reinterpret_cast<PFN_vkDestroySwapchainKHR>(vk::GetDeviceProcAddr(device(), "vkDestroySwapchainKHR"));
+    vk::AcquireNextImageKHR = reinterpret_cast<PFN_vkAcquireNextImageKHR>(vk::GetDeviceProcAddr(device(), "vkAcquireNextImageKHR"));
 
     return true;
 }
@@ -614,6 +615,11 @@ int main(int argc, char **argv) {
     SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+
+#if !defined(ANDROID)
+    // Set VK_LAYER_PATH so that the loader can find the layers
+    SetEnvironment("VK_LAYER_PATH", LAYER_BUILD_LOCATION);
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/generator_source/test_layer_location.h
+++ b/tests/generator_source/test_layer_location.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+/*
+ * This file is processed using CMake to define the build folder of the layers.
+ * Thus, the layers can set VK_LAYER_PATH on startup and be able to find all of the layers immediately, rather than relying on
+ * the user to set the path properly.
+ *
+ * File Usage: Just include "test_layer_location.h" in the executable
+ */
+
+#pragma once
+
+#define LAYER_BUILD_LOCATION "$<TARGET_FILE_DIR:VkLayer_khronos_synchronization2>"

--- a/utils/vk_layer_config.cpp
+++ b/utils/vk_layer_config.cpp
@@ -115,7 +115,8 @@ bool SetEnvironment(const char *name, const char *value) {
     return (setenv(name, value, 0) == 0) ? true : false;
 #elif defined(_WIN32)
     int size = GetEnvironmentVariable(name, NULL, 0);
-    if (size != 0) {
+    // only overwrite if the variable isn't already set.
+    if (size == 0) {
         return static_cast<bool>(SetEnvironmentVariable(name, value));
     }
     return true;


### PR DESCRIPTION
When tests are executing, they need to find the layers built by this project. However, the only robust way to do that is to set the VK_LAYER_PATH environment variable with the correct path. While it would be simple to set the build path of the layers into a header file, because of multi-configuration (like visual studio), some extra CMake logic is required to rename the header file containing the path using the current build configuration as the source.