### PR TITLE
shaderObject: Add missing extensions

### DIFF
--- a/layers/generated/shader_object_constants.h
+++ b/layers/generated/shader_object_constants.h
@@ -30,22 +30,26 @@ enum AdditionalExtensionFlagBits {
     EXTENDED_DYNAMIC_STATE_3        = 1u << 5,
     VERTEX_INPUT_DYNAMIC            = 1u << 6,
     GRAPHICS_PIPELINE_LIBRARY       = 1u << 7,
-    DRIVER_PROPERTIES               = 1u << 8,
-    TRANSFORM_FEEDBACK              = 1u << 9,
-    CONSERVATIVE_RASTERIZATION      = 1u << 10,
-    DEPTH_CLIP_ENABLE               = 1u << 11,
-    SAMPLE_LOCATIONS                = 1u << 12,
-    PROVOKING_VERTEX                = 1u << 13,
-    LINE_RASTERIZATION              = 1u << 14,
-    DEPTH_CLIP_CONTROL              = 1u << 15,
-    NV_FRAMEBUFFER_MIXED_SAMPLES    = 1u << 16,
-    NV_COVERAGE_REDUCTION_MODE      = 1u << 17,
-    NV_FRAGMENT_COVERAGE_TO_COLOR   = 1u << 18,
-    NV_CLIP_SPACE_W_SCALING         = 1u << 19,
-    NV_VIEWPORT_SWIZZLE             = 1u << 20,
-    NV_SHADING_RATE_IMAGE           = 1u << 21,
-    NV_REPRESENTATIVE_FRAGMENT_TEST = 1u << 22,
-    SHADER_OBJECT                   = 1u << 23,
+    PIPELINE_LIBRARY                = 1u << 8,
+    MULTIVIEW                       = 1u << 9,
+    CREATE_RENDERPASS_2             = 1u << 10,
+    DEPTH_STENCIL_RESOLVE           = 1u << 11,
+    DRIVER_PROPERTIES               = 1u << 12,
+    TRANSFORM_FEEDBACK              = 1u << 13,
+    CONSERVATIVE_RASTERIZATION      = 1u << 14,
+    DEPTH_CLIP_ENABLE               = 1u << 15,
+    SAMPLE_LOCATIONS                = 1u << 16,
+    PROVOKING_VERTEX                = 1u << 17,
+    LINE_RASTERIZATION              = 1u << 18,
+    DEPTH_CLIP_CONTROL              = 1u << 19,
+    NV_FRAMEBUFFER_MIXED_SAMPLES    = 1u << 20,
+    NV_COVERAGE_REDUCTION_MODE      = 1u << 21,
+    NV_FRAGMENT_COVERAGE_TO_COLOR   = 1u << 22,
+    NV_CLIP_SPACE_W_SCALING         = 1u << 23,
+    NV_VIEWPORT_SWIZZLE             = 1u << 24,
+    NV_SHADING_RATE_IMAGE           = 1u << 25,
+    NV_REPRESENTATIVE_FRAGMENT_TEST = 1u << 26,
+    SHADER_OBJECT                   = 1u << 27,
 };
 using AdditionalExtensionFlags = uint32_t;
 
@@ -58,6 +62,10 @@ inline AdditionalExtensionFlags AdditionalExtensionStringToFlag(const char* pExt
     if (strncmp(pExtensionName, VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,    VK_MAX_EXTENSION_NAME_SIZE) == 0) { return EXTENDED_DYNAMIC_STATE_3; }
     if (strncmp(pExtensionName, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,  VK_MAX_EXTENSION_NAME_SIZE) == 0) { return VERTEX_INPUT_DYNAMIC; }
     if (strncmp(pExtensionName, VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME,   VK_MAX_EXTENSION_NAME_SIZE) == 0) { return GRAPHICS_PIPELINE_LIBRARY; }
+    if (strncmp(pExtensionName, VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,            VK_MAX_EXTENSION_NAME_SIZE) == 0) { return PIPELINE_LIBRARY; }
+    if (strncmp(pExtensionName, VK_KHR_MULTIVIEW_EXTENSION_NAME,                   VK_MAX_EXTENSION_NAME_SIZE) == 0) { return MULTIVIEW; }
+    if (strncmp(pExtensionName, VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,         VK_MAX_EXTENSION_NAME_SIZE) == 0) { return CREATE_RENDERPASS_2; }
+    if (strncmp(pExtensionName, VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME,       VK_MAX_EXTENSION_NAME_SIZE) == 0) { return DEPTH_STENCIL_RESOLVE; }
     if (strncmp(pExtensionName, VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,           VK_MAX_EXTENSION_NAME_SIZE) == 0) { return DRIVER_PROPERTIES; }
     if (strncmp(pExtensionName, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,          VK_MAX_EXTENSION_NAME_SIZE) == 0) { return TRANSFORM_FEEDBACK; }
     if (strncmp(pExtensionName, VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,  VK_MAX_EXTENSION_NAME_SIZE) == 0) { return CONSERVATIVE_RASTERIZATION; }
@@ -91,6 +99,10 @@ constexpr ExtensionData kAdditionalExtensions[] = {
     { VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,    EXTENDED_DYNAMIC_STATE_3 },
     { VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,  VERTEX_INPUT_DYNAMIC },
     { VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME,   GRAPHICS_PIPELINE_LIBRARY },
+    { VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,            PIPELINE_LIBRARY },
+    { VK_KHR_MULTIVIEW_EXTENSION_NAME,                   MULTIVIEW },
+    { VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,         CREATE_RENDERPASS_2 },
+    { VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME,       DEPTH_STENCIL_RESOLVE },
     { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,           DRIVER_PROPERTIES },
 };
 

--- a/scripts/shader_object_data.json
+++ b/scripts/shader_object_data.json
@@ -801,6 +801,22 @@
             "dynamic_states": []
         },
         {
+            "name": "PIPELINE_LIBRARY",
+            "extension_name_macro": "VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME"
+        },
+        {
+            "name": "MULTIVIEW",
+            "extension_name_macro": "VK_KHR_MULTIVIEW_EXTENSION_NAME"
+        },
+        {
+            "name": "CREATE_RENDERPASS_2",
+            "extension_name_macro": "VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME"
+        },
+        {
+            "name": "DEPTH_STENCIL_RESOLVE",
+            "extension_name_macro": "VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME"
+        },
+        {
             "name": "DRIVER_PROPERTIES",
             "extension_name_macro": "VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME"
         }


### PR DESCRIPTION
For any extension being enabled on a device, their dependencies must be in the ppEnabledExtensionNames list as well