### PR TITLE
shaderObject: Create a pipeline before beginning xfb

### DIFF
--- a/layers/generated/shader_object_entry_points_x_macros.inl
+++ b/layers/generated/shader_object_entry_points_x_macros.inl
@@ -43,6 +43,7 @@
     ENTRY_POINT(BeginCommandBuffer)\
     ENTRY_POINT(CmdBeginRendering)\
     ENTRY_POINT_ALIAS(CmdBeginRenderingKHR, CmdBeginRendering)\
+    ENTRY_POINT(CmdBeginTransformFeedbackEXT)\
     ENTRY_POINT(GetShaderBinaryDataEXT)\
     ENTRY_POINT(CmdSetViewportWithCount)\
     ENTRY_POINT_ALIAS(CmdSetViewportWithCountEXT, CmdSetViewportWithCount)\

--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -3376,6 +3376,12 @@ static VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(VkCommandBuffer commandBuffe
     cmd_data->device_data->vtable.CmdBeginRendering(commandBuffer, pRenderingInfo);
 }
 
+static VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers, const VkDeviceSize* pCounterBufferOffsets) {
+    auto cmd_data = GetCommandBufferData(commandBuffer);
+    UpdateDrawState(*cmd_data, commandBuffer);
+    cmd_data->device_data->vtable.CmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
+}
+
 static VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                           const VkViewport* pViewports) {
     auto cmd_data = GetCommandBufferData(commandBuffer);

--- a/scripts/shader_object_data.json
+++ b/scripts/shader_object_data.json
@@ -973,6 +973,9 @@
                     "CmdBeginRenderingKHR"
                 ],
                 [
+                    "CmdBeginTransformFeedbackEXT"
+                ],
+                [
                     "GetShaderBinaryDataEXT"
                 ],
                 [


### PR DESCRIPTION
A pipeline must be bound before calling vkCmdBeginTransformFeedbackEXT