### PR TITLE
layers: Use correct JSON type in manifests

### DIFF
--- a/layers/json/VkLayer_khronos_shader_object.json.in
+++ b/layers/json/VkLayer_khronos_shader_object.json.in
@@ -11,7 +11,7 @@
         "device_extensions": [
             {
                 "name" : "VK_EXT_shader_object",
-                "spec_version" : 1,
+                "spec_version" : "1",
                 "entrypoints": [
                     "vkCmdBindShadersEXT",
                     "vkCmdBindVertexBuffers2EXT",

--- a/layers/json/VkLayer_khronos_timeline_semaphore.json.in
+++ b/layers/json/VkLayer_khronos_timeline_semaphore.json.in
@@ -10,7 +10,7 @@
         "device_extensions": [
             {
                 "name" : "VK_KHR_timeline_semaphore",
-                "spec_version" : 1
+                "spec_version" : "1"
             }
         ]
     }


### PR DESCRIPTION
The `spec_version` field is expected to be a string containing a number rather than a raw number. This commit fixes both the timeline sempahore layer and the shader object layer to conform.