### PR TITLE
layers: Fix EnumPhysDevs in decompression

### DIFF
--- a/layers/decompression/decompression.cpp
+++ b/layers/decompression/decompression.cpp
@@ -352,7 +352,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
     auto instance_data = GetInstanceData(instance);
     VkResult result =
         instance_data->vtable.EnumeratePhysicalDevices(instance_data->instance, pPhysicalDeviceCount, pPhysicalDevices);
-    if (result == VK_SUCCESS && pPhysicalDevices != nullptr) {
+    if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pPhysicalDevices != nullptr) {
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
             VkPhysicalDeviceProperties properties{};
             auto physical_device = pPhysicalDevices[i];
@@ -909,7 +909,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDecompressMemoryIndirectCountNV(VkCommandBuffer co
                 bufferBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
                 bufferBarrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
                 device_data->vtable.CmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                    VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, 0, 1, &bufferBarrier, 0, 0);
+                                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, 0, 1, &bufferBarrier, 0, 0);
             }
 
             device_data->vtable.CmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,


### PR DESCRIPTION
EnumeratePhysicalDevices was only looking for VK_SUCCESS when trying to update its own maps of found physical device handles. This is a problem when the application intentionally only queries for 1 physical device, getting VK_INCOMPLETE but not following up for all physical devices. The tests intentionally look for 1 physical device, triggering this error.

The fix is to update the map of found physical devices if either VK_SUCCESS or VK_INCOMPLETE is returned.