### PR TITLE
CMake Cleanup: Compile Definitions and visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,35 @@ if (NOT TARGET Vulkan::Headers)
     find_package(VulkanHeaders CONFIG REQUIRED QUIET)
 endif()
 
-add_compile_definitions(VK_ENABLE_BETA_EXTENSIONS)
+target_compile_definitions(Vulkan::Headers INTERFACE VK_ENABLE_BETA_EXTENSIONS) # Enable beta Vulkan extensions
+if(WIN32)
+    target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_WIN32_KHR)
+elseif(ANDROID)
+    target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_ANDROID_KHR)
+elseif(APPLE)
+    target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_MACOS_MVK VK_USE_PLATFORM_METAL_EXT)
+else()
+    option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
+    option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
+    option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
+
+    find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
+
+    if(BUILD_WSI_XCB_SUPPORT)
+        pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
+        target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_XCB_KHR)
+    endif()
+
+    if(BUILD_WSI_XLIB_SUPPORT)
+        pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
+        target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_XLIB_KHR VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+    endif()
+
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        pkg_check_modules(WAYlAND_CLIENT QUIET REQUIRED IMPORTED_TARGET wayland-client)
+        target_compile_definitions(Vulkan::Headers INTERFACE VK_USE_PLATFORM_WAYLAND_KHR)
+    endif()
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -111,33 +139,6 @@ if(MAKE_C_COMPILER_ID MATCHES "Clang")
 
 endif()
 
-option(BUILD_TESTS "Build tests")
-if(BUILD_TESTS)
-    # Options for Linux only
-    if(UNIX AND NOT APPLE) # i.e. Linux
-        find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
-
-        option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
-        option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
-        option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
-
-        if(BUILD_WSI_XCB_SUPPORT)
-            pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
-            add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
-        endif()
-
-        if(BUILD_WSI_XLIB_SUPPORT)
-            pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
-            add_definitions(-DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT)
-        endif()
-
-        if(BUILD_WSI_WAYLAND_SUPPORT)
-            pkg_check_modules(WAYLAND REQUIRED QUIET IMPORTED_TARGET wayland-client)
-            add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
-        endif()
-    endif()
-endif()
-
 option(VEL_CODEGEN "Enable code generation")
 if (VEL_CODEGEN)
     find_package(Python3 REQUIRED QUIET)
@@ -150,6 +151,8 @@ endif()
 
 add_subdirectory(layers)
 add_subdirectory(utils)
+
+option(BUILD_TESTS "Build tests")
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
 
 include(GNUInstallDirs)
 
@@ -93,8 +95,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
                         -Wno-unused-parameter
                         -Wno-missing-field-initializers
                         -fno-strict-aliasing
-                        -fno-builtin-memcmp
-                        -fvisibility=hidden)
+                        -fno-builtin-memcmp)
 
     set(CMAKE_C_STANDARD 99)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,17 @@ project(Vulkan-ExtensionLayer)
 
 add_subdirectory(scripts)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
+
+include(GNUInstallDirs)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 if (NOT TARGET Vulkan::Headers)
     find_package(VulkanHeaders CONFIG REQUIRED QUIET)
 endif()
@@ -55,23 +66,7 @@ else()
     endif()
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
-set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
-
-include(GNUInstallDirs)
-
-# Enable IDE GUI folders
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-# "Helper" targets that don't have interesting source code should set their FOLDER property to this
-set(LAYERS_HELPER_FOLDER "Helper Targets")
-
-# NOTE: The idiom for open source projects is to not enable warnings as errors.
-# This reduces problems for users who simply want to build the repository.
-option(BUILD_WERROR "Treat compiler warnings as errors" OFF)
+option(BUILD_WERROR "Treat compiler warnings as errors")
 if (BUILD_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
 endif()

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -95,7 +95,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main extlayer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++17 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
 LOCAL_LDLIBS := -llog -landroid -ldl
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -118,7 +118,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main extlayer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++17 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden -DVALIDATION_APK
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden -DVALIDATION_APK
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS := -llog -landroid -ldl
 LOCAL_LDFLAGS := -u ANativeActivity_onCreate

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,8 +35,6 @@ endif()
 
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
-    # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
-    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
     # If MSVC, allow Windows to use multiprocessor compilation
     if(MSVC)
     add_compile_options(/MP)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,17 +34,13 @@ if(ANNOTATED_SPEC_LINK)
 endif()
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
     # If MSVC, allow Windows to use multiprocessor compilation
     if(MSVC)
     add_compile_options(/MP)
     endif()
-elseif(ANDROID)
-    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(APPLE)
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 endif()
 
 if(WIN32)
@@ -82,6 +78,10 @@ add_test(NAME vk_extension_layer_tests COMMAND vk_extension_layer_tests)
 
 if(MSVC_IDE)
     set_target_properties(vk_extension_layer_tests PROPERTIES VS_DEBUGGER_ENVIRONMENT "VK_LAYER_PATH=$<TARGET_FILE_DIR:VkLayer_khronos_synchronization2>")
+endif()
+
+if (NOT MSVC)
+    target_compile_options(vk_extension_layer_tests PRIVATE "-Wno-sign-compare")
 endif()
 
 add_dependencies(vk_extension_layer_tests VkLayer_khronos_synchronization2 VkLayer_khronos_memory_decompression generate_test_layer_location)
@@ -135,25 +135,12 @@ target_link_libraries(vk_extension_layer_tests PRIVATE
     glslang::HLSL
     glslang::SPIRV
     glslang::SPVRemapper
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::XCB>
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
+    ${CMAKE_DL_LIBS}
 )
 
 target_compile_definitions(vk_extension_layer_tests PUBLIC SHADER_OBJECT_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_khronos_shader_object>")
-
-# Specify target_link_libraries
-if(NOT WIN32)
-    target_compile_options(vk_extension_layer_tests PRIVATE "-Wno-sign-compare")
-    target_link_libraries(vk_extension_layer_tests PRIVATE ${CMAKE_DL_LIBS} VkExtLayer_utils)
-    if(BUILD_WSI_XCB_SUPPORT)
-        target_link_libraries(vk_extension_layer_tests PRIVATE PkgConfig::XCB)
-    endif()
-
-    if (BUILD_WSI_XLIB_SUPPORT)
-        target_link_libraries(vk_extension_layer_tests PRIVATE PkgConfig::X11)
-    endif()
-
-    if(BUILD_WSI_WAYLAND_SUPPORT)
-        target_link_libraries(vk_extension_layer_tests PRIVATE PkgConfig::WAYLAND)
-    endif()
-endif()
 
 install(TARGETS vk_extension_layer_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,10 +29,6 @@ add_custom_command(
     )
 add_custom_target (generate_test_layer_location DEPENDS "${CMAKE_BINARY_DIR}/test_layer_location.h")
 
-if(ANNOTATED_SPEC_LINK)
-    add_definitions(-DANNOTATED_SPEC_LINK=${ANNOTATED_SPEC_LINK})
-endif()
-
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     # If MSVC, allow Windows to use multiprocessor compilation

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -21,10 +21,6 @@
 # files directly in layers.
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
-if(ANNOTATED_SPEC_LINK)
-    add_definitions(-DANNOTATED_SPEC_LINK=${ANNOTATED_SPEC_LINK})
-endif()
-
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     if(MSVC)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -26,17 +26,13 @@ if(ANNOTATED_SPEC_LINK)
 endif()
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     if(MSVC)
         # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
         add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
         # Allow Windows to use multiprocessor compilation
         add_compile_options(/MP)
     endif()
-elseif(ANDROID)
-    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(APPLE)
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 endif()
 
 if(WIN32)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -19,7 +19,6 @@
 # For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search path that can't be easily
 # modified to point it to the same directory that contains the layers. TODO: This should not be a library -- in future, include
 # files directly in layers.
-add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -28,8 +28,6 @@ endif()
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     if(MSVC)
-        # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
-        add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
         # Allow Windows to use multiprocessor compilation
         add_compile_options(/MP)
     endif()


### PR DESCRIPTION
- cmake: Fix vulkan platform defines
- cmake: Fix visibility code
- cmake: Remove old workaround for VS 2015
- cmake: Remove ANNOTATED_SPEC_LINK
- cmake: Remove NV_EXTENSIONS AMD_EXTENSIONS
