### PR TITLE
shaderObject: Fix potential use of wrong pipeline

### DIFF
--- a/layers/generated/shader_object_full_draw_state_struct_members.inl
+++ b/layers/generated/shader_object_full_draw_state_struct_members.inl
@@ -86,19 +86,19 @@ public:
         return color_blend_attachment_states_;
     }
     
-    void SetShader(uint32_t index, Shader* const& element) {
-        if (element == shaders_[index]) {
+    void SetComparableShader(uint32_t index, ComparableShader const& element) {
+        if (element == comparable_shaders_[index]) {
             return;
         }
         dirty_hash_bits_.set(MISC);
         MarkDirty();
-        shaders_[index] = element;
+        comparable_shaders_[index] = element;
     }
-    Shader* const& GetShader(uint32_t index) const {
-        return shaders_[index];
+    ComparableShader const& GetComparableShader(uint32_t index) const {
+        return comparable_shaders_[index];
     }
-    Shader* const* GetShaderPtr() const {
-        return shaders_;
+    ComparableShader const* GetComparableShaderPtr() const {
+        return comparable_shaders_;
     }
     
     void SetCullMode(VkCullModeFlags const& element) {
@@ -748,7 +748,7 @@ public:
         }
 
         for (uint32_t i = 0; i < NUM_SHADERS; ++i) {
-            if (!(o.shaders_[i] == shaders_[i])) {
+            if (!(o.comparable_shaders_[i] == comparable_shaders_[i])) {
                 return false;
             }
         }
@@ -977,22 +977,22 @@ public:
 
     bool CompareStateSubset(FullDrawStateData const& o, VkGraphicsPipelineLibraryFlagBitsEXT flag) const {
         if (flag == VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {
-            if (o.shaders_[VERTEX_SHADER] != shaders_[VERTEX_SHADER]) {
+            if (!(o.comparable_shaders_[VERTEX_SHADER] == comparable_shaders_[VERTEX_SHADER])) {
                 return false;
             }
-            if (o.shaders_[TESSELLATION_CONTROL_SHADER] != shaders_[TESSELLATION_CONTROL_SHADER]) {
+            if (!(o.comparable_shaders_[TESSELLATION_CONTROL_SHADER] == comparable_shaders_[TESSELLATION_CONTROL_SHADER])) {
                 return false;
             }
-            if (o.shaders_[TESSELLATION_EVALUATION_SHADER] != shaders_[TESSELLATION_EVALUATION_SHADER]) {
+            if (!(o.comparable_shaders_[TESSELLATION_EVALUATION_SHADER] == comparable_shaders_[TESSELLATION_EVALUATION_SHADER])) {
                 return false;
             }
-            if (o.shaders_[GEOMETRY_SHADER] != shaders_[GEOMETRY_SHADER]) {
+            if (!(o.comparable_shaders_[GEOMETRY_SHADER] == comparable_shaders_[GEOMETRY_SHADER])) {
                 return false;
             }
-            if (o.shaders_[TASK_SHADER] != shaders_[TASK_SHADER]) {
+            if (!(o.comparable_shaders_[TASK_SHADER] == comparable_shaders_[TASK_SHADER])) {
                 return false;
             }
-            if (o.shaders_[MESH_SHADER] != shaders_[MESH_SHADER]) {
+            if (!(o.comparable_shaders_[MESH_SHADER] == comparable_shaders_[MESH_SHADER])) {
                 return false;
             }
             if (!(o.cull_mode_ == cull_mode_)) {
@@ -1029,7 +1029,7 @@ public:
 
         }
         if (flag == VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT) {
-            if (o.shaders_[FRAGMENT_SHADER] != shaders_[FRAGMENT_SHADER]) {
+            if (!(o.comparable_shaders_[FRAGMENT_SHADER] == comparable_shaders_[FRAGMENT_SHADER])) {
                 return false;
             }
             if (!(o.depth_bounds_test_enable_ == depth_bounds_test_enable_)) {
@@ -1171,7 +1171,7 @@ private:
     VkFormat* color_attachment_formats_{};
     uint32_t num_color_attachments_{};
     VkPipelineColorBlendAttachmentState* color_blend_attachment_states_{};
-    Shader* shaders_[NUM_SHADERS];
+    ComparableShader comparable_shaders_[NUM_SHADERS];
     VkCullModeFlags cull_mode_{};
     VkBool32 depth_bounds_test_enable_{};
     VkCompareOp depth_compare_op_{};

--- a/scripts/shader_object_data.json
+++ b/scripts/shader_object_data.json
@@ -919,8 +919,8 @@
             "init_time_array_length": "max_color_attachments"
         },
         {
-            "type": "Shader*",
-            "name": "shader",
+            "type": "ComparableShader",
+            "name": "comparable_shader",
             "compile_time_array_length": "NUM_SHADERS"
         }
     ],

--- a/scripts/shader_object_generator.py
+++ b/scripts/shader_object_generator.py
@@ -380,7 +380,7 @@ def generate_full_draw_state_struct_members(data):
         out_file.write(f'        if (flag == {subset_flag}) {{\n')
 
         for shader in data['pipeline_subsets'][subset_flag]['shaders']:
-            out_file.write(f'            if (o.shaders_[{shader}] != shaders_[{shader}]) {{\n')
+            out_file.write(f'            if (!(o.comparable_shaders_[{shader}] == comparable_shaders_[{shader}])) {{\n')
             out_file.write(f'                return false;\n')
             out_file.write(f'            }}\n')
 


### PR DESCRIPTION
closes #269 

It is a quite hacky way to do it as I am not familiar with the code generator.
It breaks the interfaces of `GetShader`/`GetShaderPtr`, but fixes its uses by adding `.pShader`.

What was changed is that every `Shader` holds unique `id` in it and `FullDrawStateData` holds it too, so even if different `Shader` gets the same address as one beforehand it is still differentiated from the old one by `id`.