### PR TITLE
cmake: Cleanup compiler/language usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ~~~
 cmake_minimum_required(VERSION 3.17.2)
 
-project(VEL LANGUAGES CXX C)
+project(VEL LANGUAGES CXX)
 
 add_subdirectory(scripts)
 
@@ -71,47 +71,27 @@ if (BUILD_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
 endif()
 
-# Platform-specific compiler switches
-if(MAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wconversion
-
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
-                        -Wno-string-conversion
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion)
-
-endif()
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall
-                        -Wextra
-                        -Wno-unused-parameter
-                        -Wno-missing-field-initializers
-                        -fno-strict-aliasing
-                        -fno-builtin-memcmp)
-
-    set(CMAKE_C_STANDARD 99)
-
-    # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
-    # all compilers until they all accept the C++17 standard.
-    if(CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.1))
-        add_compile_options(-Wimplicit-fallthrough=0)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wpointer-arith
+    )
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        add_compile_options(
+            -Wconversion
+            -Wimplicit-fallthrough
+            -Wstring-conversion
+        )
     endif()
 elseif(MSVC)
-    add_compile_options("/W3")
-    # Warn about nested declarations
-    add_compile_options("/w34456")
-    # Warn about potentially uninitialized variables
-    add_compile_options("/w34701")
-    add_compile_options("/w34703")
-    # Warn about different indirection types.
-    add_compile_options("/w34057")
-    # Warn about signed/unsigned mismatch.
-    add_compile_options("/w34245")
-    # Warn zero sized arrays in structs or unions
-    add_compile_options("/wd4200")
+    add_compile_options(
+        /W4
+        /we5038 # Enable warning about MIL ordering in constructors
+    )
+
+    # Enforce stricter ISO C++
+    add_compile_options(/permissive-)
 
     # PDBs aren't generated on Release builds by default.
     add_compile_options("$<$<CONFIG:Release>:/Zi>")
@@ -120,19 +100,11 @@ elseif(MSVC)
     add_link_options("$<$<CONFIG:Release>:/OPT:REF>")
     # Merge duplicate data/functions
     add_link_options("$<$<CONFIG:Release>:/OPT:ICF>")
-endif()
 
-if(MAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wconversion
+    # Allow usage of unsafe CRT functions and minimize what Windows.h leaks
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS NOMINMAX WIN32_LEAN_AND_MEAN)
 
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
-                        -Wno-string-conversion
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion)
-
+    add_compile_options($<$<BOOL:${MSVC_IDE}>:/MP>) # Speed up Visual Studio builds
 endif()
 
 option(VEL_CODEGEN "Enable code generation")

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -16,11 +16,14 @@
 # limitations under the License.
 # ~~~
 
-# System-specific macros to create a library target.
-macro(AddVkLayer target LAYER_COMPILE_DEFINITIONS)
-    add_library(VkLayer_${target} MODULE ${ARGN})
-    target_compile_definitions(VkLayer_${target} PUBLIC ${LAYER_COMPILE_DEFINITIONS})
+# TODO: Remove this macro. It's more confusing than helpful.
+macro(AddVkLayer target)
+    add_library(VkLayer_${target} MODULE)
+
+    target_include_directories(VkLayer_${target} PRIVATE .)
+
     target_link_libraries(VkLayer_${target} PRIVATE VkExtLayer_utils Vulkan::Headers)
+
     if(MSVC)
         target_link_options(VkLayer_${target} PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_${target}.def)
         target_compile_definitions(VkLayer_${target} PUBLIC NOMINMAX)
@@ -36,51 +39,28 @@ macro(AddVkLayer target LAYER_COMPILE_DEFINITIONS)
     endif()
 endmacro()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
-                    ${PROJECT_SOURCE_DIR}/utils
-                    ${PROJECT_SOURCE_DIR}/utils/generated)
-
-if(MSVC)
-    # Applies to all configurations
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)
-    # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
-    add_compile_options("/bigobj")
-    # Allow Windows to use multiprocessor compilation
-    add_compile_options(/MP)
-    # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is
-    # that constructor initializers are now fixed to clear the struct members.
-    add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
-endif()
-
 if(NOT WIN32)
-set(TIMELINE_SEMAPHORE_FILES
-    hash_table.cpp
-    timeline_semaphore.c)
-
-AddVkLayer(khronos_timeline_semaphore ""
-    ${TIMELINE_SEMAPHORE_FILES})
+    AddVkLayer(khronos_timeline_semaphore)
+    target_sources(VkLayer_khronos_timeline_semaphore PRIVATE
+        hash_table.cpp
+        timeline_semaphore.c
+    )
 endif()
 
-set(SYNCHRONIZATION2_FILES
-    synchronization2.cpp)
+AddVkLayer(khronos_synchronization2)
+target_sources(VkLayer_khronos_synchronization2 PRIVATE
+    synchronization2.cpp
+)
 
-AddVkLayer(khronos_synchronization2 ""
-    ${SYNCHRONIZATION2_FILES})
+AddVkLayer(khronos_shader_object)
+target_sources(VkLayer_khronos_shader_object PRIVATE
+    shader_object.cpp
+)
 
-set(SHADER_OBJECT_FILES
-    shader_object.cpp)
-
-AddVkLayer(khronos_shader_object ""
-    ${SHADER_OBJECT_FILES})
-
-set(DECOMPRESSION_FILES
-    decompression/decompression.cpp)
-
-AddVkLayer(khronos_memory_decompression ""
-    ${DECOMPRESSION_FILES})
+AddVkLayer(khronos_memory_decompression)
+target_sources(VkLayer_khronos_memory_decompression PRIVATE
+    decompression/decompression.cpp
+)
 
 set(TARGET_NAMES VkLayer_khronos_timeline_semaphore VkLayer_khronos_synchronization2 VkLayer_khronos_shader_object VkLayer_khronos_memory_decompression)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,53 +29,23 @@ add_custom_command(
     )
 add_custom_target (generate_test_layer_location DEPENDS "${CMAKE_BINARY_DIR}/test_layer_location.h")
 
-if(WIN32)
-    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
-    # If MSVC, allow Windows to use multiprocessor compilation
-    if(MSVC)
-    add_compile_options(/MP)
-    endif()
-endif()
+add_executable(vk_extension_layer_tests)
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-
-    # If MSVC, disable some signed/unsigned mismatch warnings.
-    if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
-    endif()
-endif()
-
-set(LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
-
-set(COMMON_CPP
+target_sources(vk_extension_layer_tests PRIVATE
+    extension_layer_tests.cpp
+    synchronization2_tests.cpp
+    decompression_tests.cpp
+    shader_object_tests.cpp
     vkrenderframework.cpp
     vktestbinding.cpp
     vktestframework.cpp
-    test_environment.cpp)
+    test_environment.cpp
+)
 
-if(NOT TARGET vulkan)
-    set(
-        CMAKE_PREFIX_PATH
-        ${CMAKE_PREFIX_PATH};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR}
-        )
-endif()
-
-set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
-add_executable(vk_extension_layer_tests
-               extension_layer_tests.cpp
-               synchronization2_tests.cpp
-               decompression_tests.cpp
-               shader_object_tests.cpp
-               ${COMMON_CPP})
 add_test(NAME vk_extension_layer_tests COMMAND vk_extension_layer_tests)
 
 if(MSVC_IDE)
     set_target_properties(vk_extension_layer_tests PROPERTIES VS_DEBUGGER_ENVIRONMENT "VK_LAYER_PATH=$<TARGET_FILE_DIR:VkLayer_khronos_synchronization2>")
-endif()
-
-if (NOT MSVC)
-    target_compile_options(vk_extension_layer_tests PRIVATE "-Wno-sign-compare")
 endif()
 
 add_dependencies(vk_extension_layer_tests VkLayer_khronos_synchronization2 VkLayer_khronos_memory_decompression generate_test_layer_location)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -15,46 +15,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-# VkExtLayer_utils library ----------------------------------------------------------------------------------------------------------
-# For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search path that can't be easily
-# modified to point it to the same directory that contains the layers. TODO: This should not be a library -- in future, include
-# files directly in layers.
+add_library(VkExtLayer_utils STATIC)
 
-if(WIN32)
-    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX)
-    if(MSVC)
-        # Allow Windows to use multiprocessor compilation
-        add_compile_options(/MP)
-    endif()
+target_sources(VkExtLayer_utils PRIVATE
+    allocator.cpp
+    vk_format_utils.cpp
+    vk_layer_config.cpp
+    generated/vk_safe_struct.cpp
+    generated/lvt_function_pointers.cpp
+)
+
+# TODO: Fix warnings
+target_compile_options(VkExtLayer_utils PUBLIC "$<IF:$<CXX_COMPILER_ID:MSVC>,/wd4100,-Wno-unused-parameter>")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VkExtLayer_utils PUBLIC -Wno-missing-field-initializers)
 endif()
-
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-
-    # If MSVC, disable some signed/unsigned mismatch warnings.
-    if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
-    endif()
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    target_compile_options(VkExtLayer_utils PUBLIC
+        -Wno-implicit-int-conversion
+        -Wno-sign-conversion
+        -Wno-string-conversion
+        -Wno-implicit-fallthrough
+        -Wno-implicit-int-float-conversion
+        -Wno-shorten-64-to-32
+    )
 endif()
-
-
-set(TARGET_NAMES
-    VkExtLayer_utils)
-add_library(VkExtLayer_utils
-            STATIC
-            ./allocator.cpp
-            ./vk_format_utils.cpp
-            ./vk_layer_config.cpp
-            ./generated/vk_safe_struct.cpp
-            ./generated/lvt_function_pointers.cpp)
+if (MSVC)
+    target_compile_options(VkExtLayer_utils PUBLIC
+        /wd4389
+        /wd4324
+        /wd4244
+        /wd4815
+        /wd4200
+        /wd4267
+        /wd4505
+        /wd4706
+    )
+endif()
 
 target_link_libraries(VkExtLayer_utils PUBLIC Vulkan::Headers)
+
 if(ANDROID)
     target_link_libraries(VkExtLayer_utils PUBLIC log)
 endif()
-if(WIN32)
-   target_compile_definitions(VkExtLayer_utils PUBLIC _CRT_SECURE_NO_WARNINGS)
-endif()
-set_target_properties(VkExtLayer_utils PROPERTIES LINKER_LANGUAGE CXX)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
-                    ${CMAKE_CURRENT_SOURCE_DIR}/generated)
+
+target_include_directories(VkExtLayer_utils PUBLIC
+    .
+    generated
+)


### PR DESCRIPTION
Only enable the CXX language to simplify CMake code

Cleanup various compiler options/settings to roughly match VVL.