### PR TITLE
shaderObject: Fix alignment fix

### DIFF
--- a/layers/generated/shader_object_full_draw_state_utility_functions.inl
+++ b/layers/generated/shader_object_full_draw_state_utility_functions.inl
@@ -18,30 +18,21 @@
  */
 
     static constexpr void ReserveMemory(AlignedMemory& aligned_memory, Limits const& limits) {
+        aligned_memory.Add<FullDrawStateData>();
         aligned_memory.Add<VkFormat>(limits.max_color_attachments);
         aligned_memory.Add<VkPipelineColorBlendAttachmentState>(limits.max_color_attachments);
         aligned_memory.Add<VkViewportSwizzleNV>(limits.max_viewports);
         aligned_memory.Add<VkVertexInputAttributeDescription>(limits.max_vertex_input_attributes);
         aligned_memory.Add<VkVertexInputBindingDescription>(limits.max_vertex_input_bindings);
-        aligned_memory.Add<FullDrawStateData>();
     }
 
     static void SetInternalArrayPointers(FullDrawStateData* state, Limits const& limits) {
         // Set array pointers to beginning of their memory
-        char* offset_ptr = (char*)state + sizeof(FullDrawStateData);
-
-        state->color_attachment_formats_ = (VkFormat*)offset_ptr;
-        offset_ptr += sizeof(VkFormat) * limits.max_color_attachments;
-
-        state->color_blend_attachment_states_ = (VkPipelineColorBlendAttachmentState*)offset_ptr;
-        offset_ptr += sizeof(VkPipelineColorBlendAttachmentState) * limits.max_color_attachments;
-
-        state->viewport_swizzles_ = (VkViewportSwizzleNV*)offset_ptr;
-        offset_ptr += sizeof(VkViewportSwizzleNV) * limits.max_viewports;
-
-        state->vertex_input_attribute_descriptions_ = (VkVertexInputAttributeDescription*)offset_ptr;
-        offset_ptr += sizeof(VkVertexInputAttributeDescription) * limits.max_vertex_input_attributes;
-
-        state->vertex_input_binding_descriptions_ = (VkVertexInputBindingDescription*)offset_ptr;
-        offset_ptr += sizeof(VkVertexInputBindingDescription) * limits.max_vertex_input_bindings;
+        AlignedMemory aligned_memory;
+        aligned_memory.SetMemoryWritePtr((char*)state + sizeof(FullDrawStateData));
+        state->color_attachment_formats_ = aligned_memory.GetNextAlignedPtr<VkFormat>(limits.max_color_attachments);
+        state->color_blend_attachment_states_ = aligned_memory.GetNextAlignedPtr<VkPipelineColorBlendAttachmentState>(limits.max_color_attachments);
+        state->viewport_swizzles_ = aligned_memory.GetNextAlignedPtr<VkViewportSwizzleNV>(limits.max_viewports);
+        state->vertex_input_attribute_descriptions_ = aligned_memory.GetNextAlignedPtr<VkVertexInputAttributeDescription>(limits.max_vertex_input_attributes);
+        state->vertex_input_binding_descriptions_ = aligned_memory.GetNextAlignedPtr<VkVertexInputBindingDescription>(limits.max_vertex_input_bindings);
     }

--- a/scripts/shader_object_generator.py
+++ b/scripts/shader_object_generator.py
@@ -461,28 +461,28 @@ def generate_full_draw_state_utility_functions(data):
     # generate GetSizeInBytes
 
     out_file.write('    static constexpr void ReserveMemory(AlignedMemory& aligned_memory, Limits const& limits) {\n')
+    out_file.write('        aligned_memory.Add<FullDrawStateData>();\n')
 
     for var_data in init_time_array_variables:
         var_type = var_data['type']
         length = var_data['init_time_array_length']
         out_file.write(f'        aligned_memory.Add<{var_type}>(limits.{length});\n')
 
-    out_file.write(f'        aligned_memory.Add<FullDrawStateData>();\n')
     out_file.write('    }\n\n')
 
     # generate SetInternalArrayPointers
 
     out_file.write('    static void SetInternalArrayPointers(FullDrawStateData* state, Limits const& limits) {\n')
     out_file.write('        // Set array pointers to beginning of their memory\n')
-    out_file.write('        char* offset_ptr = (char*)state + sizeof(FullDrawStateData);\n')
+    out_file.write('        AlignedMemory aligned_memory;\n')
+    out_file.write('        aligned_memory.SetMemoryWritePtr((char*)state + sizeof(FullDrawStateData));\n')
 
     for var_data in init_time_array_variables:
         var_name_private = get_private_variable_name(var_data)
         var_type = var_data['type']
         length = var_data['init_time_array_length']
 
-        out_file.write(f'\n        state->{var_name_private} = ({var_type}*)offset_ptr;\n')
-        out_file.write(f'        offset_ptr += sizeof({var_type}) * limits.{length};\n')
+        out_file.write(f'        state->{var_name_private} = aligned_memory.GetNextAlignedPtr<{var_type}>(limits.{length});\n')
 
     out_file.write('    }\n')
 


### PR DESCRIPTION
The fix of alignment issues didn't fix them (memory was allocated with respect to alignment, but there were still issues e.g. in `FullDrawStateData` that storage was calculated in different order than actually assigned and also was not properly aligned).

I've rewritten the change to support any change to alignment and made it actually align the pointers and made the bytes alignment process more explicit.

Also fixed too late allocation of private slots.