### PR TITLE
layers: Fix inconsistant naming convensions

### DIFF
--- a/docs/memory_decompression_layer.md
+++ b/docs/memory_decompression_layer.md
@@ -69,8 +69,7 @@ To force the layer to be enabled for Vulkan applications, you can set the `VK_IN
 
     export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_memory_decompression
 
-To force the layer to be enabled for Vulkan applications, even though the Vulkan implementation supports `VK_NV_memory_decompression` extension, you can
-set the `VK_MEMORY_DECOMPRESSION_FORCE_ENABLE` environment variable in the following way:
+To force the layer to be enabled for Vulkan applications, even though the Vulkan implementation supports `VK_NV_memory_decompression` extension, you can set the `VK_MEMORY_DECOMPRESSION_FORCE_ENABLE` environment variable in the following way:
 
 **Windows**
 
@@ -142,11 +141,11 @@ The easiest way to set a property is from the ADB shell:
 To set force enable, which on desktop uses `VK_MEMORY_DECOMPRESSION_FORCE_ENABLE`
 set the following property:
 
-    debug.vulkan.decompression
+    debug.vulkan.memory_decompression.force_enable
 
 Which you can set in the following way:
 
-    adb shell "setprop debug.vulkan.decompression true"
+    adb shell "setprop debug.vulkan.memory_decompression.force_enable true"
 
 <br></br>
 

--- a/docs/shader_object_layer.md
+++ b/docs/shader_object_layer.md
@@ -65,6 +65,16 @@ To force the layer to be enabled for Vulkan applications, you can set the `VK_IN
 
     export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_shader_object
 
+To force the layer to be enabled for Vulkan applications, even though the Vulkan implementation supports `VK_EXT_shader_object` extension, you can set the `VK_SHADER_OBJECT_FORCE_ENABLE` environment variable in the following way:
+
+**Windows**
+
+    set VK_SHADER_OBJECT_FORCE_ENABLE=true
+
+**Linux/MacOS**
+
+    export VK_SHADER_OBJECT_FORCE_ENABLE=true
+
 <br>
 
 ### Settings Priority

--- a/docs/synchronization2_layer.md
+++ b/docs/synchronization2_layer.md
@@ -63,6 +63,16 @@ To force the layer to be enabled for Vulkan applications, you can set the `VK_IN
 
     export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_synchronization2
 
+To force the layer to be enabled for Vulkan applications, even though the Vulkan implementation supports `VK_KHR_synchronization2` extension, you can set the `VK_SYNCHRONIZATION2_FORCE_ENABLE` environment variable in the following way:
+
+**Windows**
+
+    set VK_VK_SYNCHRONIZATION2_FORCE_ENABLE=true
+
+**Linux/MacOS**
+
+    export VK_VK_SYNCHRONIZATION2_FORCE_ENABLE=true
+
 <br></br>
 
 ### Android
@@ -125,11 +135,11 @@ The easiest way to set a property is from the ADB shell:
 To set force enable, which on desktop uses `VK_SYNC2_FORCE_ENABLE`
 set the following property:
 
-    debug.sync2_force_enable
+    debug.vulkan.synchronization2.force_enable
 
 Which you can set in the following way:
 
-    adb shell "setprop debug.sync2_force_enable true"
+    adb shell "setprop debug.vulkan.synchronization2.force_enable true"
 
 <br></br>
 

--- a/layers/decompression/decompression.cpp
+++ b/layers/decompression/decompression.cpp
@@ -124,7 +124,7 @@ static const VkLayerProperties kGlobalLayer = {
     "VK_LAYER_KHRONOS_memory_decompression",
     VK_HEADER_VERSION_COMPLETE,
     1,
-    "Default memory_decompression layer",
+    "Default memory decompression layer",
 };
 
 static const VkExtensionProperties kDeviceExtension = {VK_NV_MEMORY_DECOMPRESSION_EXTENSION_NAME,
@@ -132,7 +132,7 @@ static const VkExtensionProperties kDeviceExtension = {VK_NV_MEMORY_DECOMPRESSIO
 
 static const char* const kEnvarForceEnable =
 #if defined(__ANDROID__)
-    "debug.vulkan.decompression";
+    "debug.vulkan.memory_decompression.force_enable";
 #else
     "VK_MEMORY_DECOMPRESSION_FORCE_ENABLE";
 #endif
@@ -140,7 +140,7 @@ static const char* const kLayerSettingsForceEnable = "khronos_memory_decompressi
 
 static const char* const kEnvarLogging =
 #if defined(__ANDROID__)
-    "debug.vulkan.decompression.logging";
+    "debug.vulkan.memory_decompression.logging";
 #else
     "VK_MEMORY_DECOMPRESSION_LOGGING";
 #endif

--- a/layers/json/VkLayer_khronos_memory_decompression.json.in
+++ b/layers/json/VkLayer_khronos_memory_decompression.json.in
@@ -6,7 +6,7 @@
         "library_path": "@JSON_LIBRARY_PATH@",
         "api_version": "@JSON_VERSION@",
         "implementation_version": "1",
-        "description": "Khronos Memory Decompression layer",
+        "description": "Khronos Decompression layer",
         "status": "STABLE",
         "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
         "instance_extensions": [],

--- a/layers/json/VkLayer_khronos_synchronization2.json.in
+++ b/layers/json/VkLayer_khronos_synchronization2.json.in
@@ -32,7 +32,7 @@
             "settings": [
                 {
                     "key": "force_enable",
-                    "env": "VK_SYNC2_FORCE_ENABLE",
+                    "env": "VK_SYNCHRONIZATION2_FORCE_ENABLE",
                     "label": "Force Enable",
                     "description": "Force the layer to be active even if the underlying driver also implements the synchonization2 extension.",
                     "type": "BOOL",

--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -77,7 +77,7 @@ std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
 
 namespace shader_object {
 
-static const char* kLayerName = "VkLayer_khronos_shader_object";
+static const char* kLayerName = "VK_LAYER_KHRONOS_shader_object";
 static const VkExtensionProperties kExtensionProperties = {VK_EXT_SHADER_OBJECT_EXTENSION_NAME, VK_EXT_SHADER_OBJECT_SPEC_VERSION};
 
 static const char* const kEnvarForceEnable =

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -50,9 +50,9 @@ static const VkExtensionProperties kDeviceExtension = {VK_KHR_SYNCHRONIZATION_2_
 
 static const char* const kEnvarForceEnable =
 #if defined(__ANDROID__)
-    "debug.vulkan.sync2.force_enable";
+    "debug.vulkan.synchronization2.force_enable";
 #else
-    "VK_SYNC2_FORCE_ENABLE";
+    "VK_SYNCHRONIZATION2_FORCE_ENABLE";
 #endif
 static const char* const kLayerSettingsForceEnable = "khronos_synchronization2.force_enable";
 
@@ -60,9 +60,9 @@ static const char* const kLayerSettingsForceEnable = "khronos_synchronization2.f
 // to be defined once?
 static const char* const kEnvarCustomStypeList =
 #if defined(__ANDROID__)
-    "debug.vulkan.sync2.custom_stype_list";
+    "debug.vulkan.synchronization2.custom_stype_list";
 #else
-    "VK_LAYER_SYNC2_CUSTOM_STYPE_LIST";
+    "VK_SYNCHRONIZATION2_CUSTOM_STYPE_LIST";
 #endif
 static const char* const kLayerSettingsCustomStypeList = "khronos_synchronization2.custom_stype_list";
 

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -48,6 +48,12 @@ static const VkLayerProperties kGlobalLayer = {
 static const VkExtensionProperties kDeviceExtension = {VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
                                                        VK_KHR_SYNCHRONIZATION_2_SPEC_VERSION};
 
+static const char* const kEnvarForceEnableRemoved =
+#if defined(__ANDROID__)
+    "debug.vulkan.sync2.force_enable";
+#else
+    "VK_SYNC2_FORCE_ENABLE";
+#endif
 static const char* const kEnvarForceEnable =
 #if defined(__ANDROID__)
     "debug.vulkan.synchronization2.force_enable";
@@ -58,6 +64,12 @@ static const char* const kLayerSettingsForceEnable = "khronos_synchronization2.f
 
 // TODO: should we try to use the same fields as ValidationLayers, so that list only needs
 // to be defined once?
+static const char* const kEnvarCustomStypeListRemoved =
+#if defined(__ANDROID__)
+    "debug.vulkan.sync2.custom_stype_list";
+#else
+    "VK_LAYER_SYNC2_CUSTOM_STYPE_LIST";
+#endif
 static const char* const kEnvarCustomStypeList =
 #if defined(__ANDROID__)
     "debug.vulkan.synchronization2.custom_stype_list";
@@ -77,6 +89,11 @@ static void string_tolower(std::string &s) {
 
 static bool GetForceEnable() {
     bool result = false;
+    std::string setting_removed = GetEnvironment(kEnvarForceEnableRemoved);
+    if (!setting_removed.empty()) {
+        LOG("%s was renamed into %s, please update your developer environment.\n", kEnvarForceEnableRemoved, kEnvarForceEnable);
+    }
+
     std::string setting = GetEnvironment(kEnvarForceEnable);
     if (setting.empty()) {
         setting = GetLayerOption(kLayerSettingsForceEnable);
@@ -147,6 +164,12 @@ static void SetCustomStypeInfo(std::string raw_id_list, const std::string &delim
 }
 
 static void SetupCustomStypes() {
+    std::string setting_removed = GetEnvironment(kEnvarCustomStypeListRemoved);
+    if (!setting_removed.empty()) {
+        LOG("%s was renamed into %s, please update your developer environment.\n", kEnvarCustomStypeListRemoved,
+            kEnvarCustomStypeList);
+    }
+
     const std::string kEnvDelim =
 #if defined(_WIN32)
         ";";

--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -31,7 +31,7 @@
 #include "vk_layer_config.h"
 
 void Sync2Test::SetUp() {
-    SetEnvironment("VK_SYNC2_FORCE_ENABLE", "1");
+    SetEnvironment("VK_SYNCHRONIZATION2_FORCE_ENABLE", "1");
     VkExtensionLayerTest::SetUp();
     SetTargetApiVersion(VK_API_VERSION_1_2);
     VkExtensionLayerTest::AddSurfaceInstanceExtension();


### PR DESCRIPTION
This change enables [using the Layer Settings library](https://github.com/KhronosGroup/Vulkan-ExtensionLayer/pull/254) that implement the VK_EXT_layer_settings extension allowing to control layer programmatically.

