### PR TITLE
layers: Implement vlGetUnknownSettings

### DIFF
--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -2590,19 +2590,37 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice devic
 void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, LayerSettings* layer_settings) {
     assert(layer_settings != nullptr);
 
-    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    const VkLayerSettingsCreateInfoEXT *pLayerSettingsCreateInfo = vlFindLayerSettingsCreateInfo(pCreateInfo);
-    vlCreateLayerSettingSet(kLayerName, pLayerSettingsCreateInfo, pAllocator, nullptr, &layerSettingSet);
+    const VkLayerSettingsCreateInfoEXT* create_info = vlFindLayerSettingsCreateInfo(pCreateInfo);
 
-    if (vlHasLayerSetting(layerSettingSet, kLayerSettingsForceEnable)) {
-        vlGetLayerSettingValue(layerSettingSet, kLayerSettingsForceEnable, layer_settings->force_enable);
+    VlLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet(kLayerName, create_info, pAllocator, nullptr, &layer_setting_set);
+
+    static const char* setting_names[] = {kLayerSettingsForceEnable, kLayerSettingsCustomSTypeInfo};
+    uint32_t setting_name_count = static_cast<uint32_t>(std::size(setting_names));
+
+    uint32_t unknown_setting_count = 0;
+    vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
+
+    if (unknown_setting_count > 0) {
+        std::vector<const char*> unknown_settings;
+        unknown_settings.resize(unknown_setting_count);
+
+        vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, &unknown_settings[0]);
+
+        for (std::size_t i = 0, n = unknown_settings.size(); i < n; ++i) {
+            LOG("Unknown %s setting listed in VkLayerSettingsCreateInfoEXT, this setting is ignored.\n", unknown_settings[i]);
+        }
     }
 
-    if (vlHasLayerSetting(layerSettingSet, kLayerSettingsCustomSTypeInfo)) {
-        vlGetLayerSettingValues(layerSettingSet, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
+        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
     }
 
-    vlDestroyLayerSettingSet(layerSettingSet, pAllocator);
+    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
+        vlGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    }
+
+    vlDestroyLayerSettingSet(layer_setting_set, pAllocator);
 }
 
 static VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo,

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -16,7 +16,9 @@
  *
  * Author: Tobias Hector <@tobski>
  * Author: Jeremy Gebben <jeremyg@lunarg.com>
+ * Author: Christophe Riccio <christophe@lunarg.com>
  */
+
 #include <vulkan/vk_layer.h>
 #include <vulkan/layer/vk_layer_settings.hpp>
 #include <ctype.h>
@@ -33,7 +35,7 @@
 #include "vk_safe_struct.h"
 #include "vk_util.h"
 
-#define kLayerSettingsForceEnable "force_device"
+#define kLayerSettingsForceEnable "force_enable"
 #define kLayerSettingsCustomSTypeInfo "custom_stype_list"
 
 // required by vk_safe_struct
@@ -180,18 +182,41 @@ static VkLayerInstanceCreateInfo* GetChainInfo(const VkInstanceCreateInfo* pCrea
 void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, LayerSettings* layer_settings) {
     assert(layer_settings != nullptr);
 
-    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(kGlobalLayer.layerName, vlFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr, &layerSettingSet);
+    const VkLayerSettingsCreateInfoEXT* create_info = vlFindLayerSettingsCreateInfo(pCreateInfo);
 
-    if (vlHasLayerSetting(layerSettingSet, kLayerSettingsForceEnable)) {
-        vlGetLayerSettingValue(layerSettingSet, kLayerSettingsForceEnable, layer_settings->force_enable);
+    VlLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet(kGlobalLayer.layerName, create_info, pAllocator, nullptr, &layer_setting_set);
+
+    static const char* setting_names[] = {
+        kLayerSettingsForceEnable,
+        kLayerSettingsCustomSTypeInfo
+    };
+    uint32_t setting_name_count = static_cast<uint32_t>(std::size(setting_names));
+
+    uint32_t unknown_setting_count = 0;
+    vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
+
+    if (unknown_setting_count > 0) {
+        std::vector<const char*> unknown_settings;
+        unknown_settings.resize(unknown_setting_count);
+
+        vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count,
+                             &unknown_settings[0]);
+
+        for (std::size_t i = 0, n = unknown_settings.size(); i < n; ++i) {
+            LOG("Unknown %s setting listed in VkLayerSettingsCreateInfoEXT, this setting is ignored.\n", unknown_settings[i]);
+        }
     }
 
-    if (vlHasLayerSetting(layerSettingSet, kLayerSettingsCustomSTypeInfo)) {
-        vlGetLayerSettingValues(layerSettingSet, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
+        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
     }
 
-    vlDestroyLayerSettingSet(layerSettingSet, pAllocator);
+    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
+        vlGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    }
+
+    vlDestroyLayerSettingSet(layer_setting_set, pAllocator);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -14,7 +14,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "ba0d57a51424de68a86326e393a65b26373e1c1f",
+            "commit": "dbeeb934ef51517ec28adb8b1dbcc5fcb205edb5",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
If the application developer set unknown settings, the layers log these settings.

Change to satisfy VK_EXT_layer_settings spec review.

Also fix broken setting names !