### PR TITLE
build: Update Vulkan-Headers and VUL to 1.3.265

### DIFF
--- a/layers/decompression/decompression.cpp
+++ b/layers/decompression/decompression.cpp
@@ -248,41 +248,41 @@ static VkLayerInstanceCreateInfo* GetChainInfo(const VkInstanceCreateInfo* pCrea
 void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, LayerSettings* layer_settings) {
     assert(layer_settings != nullptr);
 
-    const VkLayerSettingsCreateInfoEXT* create_info = vlFindLayerSettingsCreateInfo(pCreateInfo);
+    const VkLayerSettingsCreateInfoEXT* create_info = vkuFindLayerSettingsCreateInfo(pCreateInfo);
 
-    VlLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(kGlobalLayer.layerName, create_info, pAllocator, nullptr, &layer_setting_set);
+    VkuLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet(kGlobalLayer.layerName, create_info, pAllocator, nullptr, &layer_setting_set);
 
     static const char* setting_names[] = {kLayerSettingsForceEnable, kLayerSettingsLogging, kLayerSettingsCustomSTypeInfo};
     uint32_t setting_name_count = static_cast<uint32_t>(std::size(setting_names));
 
     uint32_t unknown_setting_count = 0;
-    vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
+    vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
 
     if (unknown_setting_count > 0) {
         std::vector<const char*> unknown_settings;
         unknown_settings.resize(unknown_setting_count);
 
-        vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, &unknown_settings[0]);
+        vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, &unknown_settings[0]);
 
         for (std::size_t i = 0, n = unknown_settings.size(); i < n; ++i) {
             LOG("Unknown %s setting listed in VkLayerSettingsCreateInfoEXT, this setting is ignored.\n", unknown_settings[i]);
         }
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
-        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
+        vkuGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsLogging)) {
-        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsLogging, layer_settings->logging);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsLogging)) {
+        vkuGetLayerSettingValue(layer_setting_set, kLayerSettingsLogging, layer_settings->logging);
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
-        vlGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
+        vkuGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
     }
 
-    vlDestroyLayerSettingSet(layer_setting_set, pAllocator);
+    vkuDestroyLayerSettingSet(layer_setting_set, pAllocator);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,

--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -2590,37 +2590,37 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice devic
 void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, LayerSettings* layer_settings) {
     assert(layer_settings != nullptr);
 
-    const VkLayerSettingsCreateInfoEXT* create_info = vlFindLayerSettingsCreateInfo(pCreateInfo);
+    const VkLayerSettingsCreateInfoEXT* create_info = vkuFindLayerSettingsCreateInfo(pCreateInfo);
 
-    VlLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(kLayerName, create_info, pAllocator, nullptr, &layer_setting_set);
+    VkuLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet(kLayerName, create_info, pAllocator, nullptr, &layer_setting_set);
 
     static const char* setting_names[] = {kLayerSettingsForceEnable, kLayerSettingsCustomSTypeInfo};
     uint32_t setting_name_count = static_cast<uint32_t>(std::size(setting_names));
 
     uint32_t unknown_setting_count = 0;
-    vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
+    vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
 
     if (unknown_setting_count > 0) {
         std::vector<const char*> unknown_settings;
         unknown_settings.resize(unknown_setting_count);
 
-        vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, &unknown_settings[0]);
+        vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, &unknown_settings[0]);
 
         for (std::size_t i = 0, n = unknown_settings.size(); i < n; ++i) {
             LOG("Unknown %s setting listed in VkLayerSettingsCreateInfoEXT, this setting is ignored.\n", unknown_settings[i]);
         }
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
-        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
+        vkuGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
-        vlGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
+        vkuGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
     }
 
-    vlDestroyLayerSettingSet(layer_setting_set, pAllocator);
+    vkuDestroyLayerSettingSet(layer_setting_set, pAllocator);
 }
 
 static VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo,

--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -182,10 +182,10 @@ static VkLayerInstanceCreateInfo* GetChainInfo(const VkInstanceCreateInfo* pCrea
 void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, LayerSettings* layer_settings) {
     assert(layer_settings != nullptr);
 
-    const VkLayerSettingsCreateInfoEXT* create_info = vlFindLayerSettingsCreateInfo(pCreateInfo);
+    const VkLayerSettingsCreateInfoEXT* create_info = vkuFindLayerSettingsCreateInfo(pCreateInfo);
 
-    VlLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(kGlobalLayer.layerName, create_info, pAllocator, nullptr, &layer_setting_set);
+    VkuLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet(kGlobalLayer.layerName, create_info, pAllocator, nullptr, &layer_setting_set);
 
     static const char* setting_names[] = {
         kLayerSettingsForceEnable,
@@ -194,13 +194,13 @@ void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocati
     uint32_t setting_name_count = static_cast<uint32_t>(std::size(setting_names));
 
     uint32_t unknown_setting_count = 0;
-    vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
+    vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count, nullptr);
 
     if (unknown_setting_count > 0) {
         std::vector<const char*> unknown_settings;
         unknown_settings.resize(unknown_setting_count);
 
-        vlGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count,
+        vkuGetUnknownSettings(create_info, setting_name_count, setting_names, &unknown_setting_count,
                              &unknown_settings[0]);
 
         for (std::size_t i = 0, n = unknown_settings.size(); i < n; ++i) {
@@ -208,15 +208,15 @@ void InitLayerSettings(const VkInstanceCreateInfo* pCreateInfo, const VkAllocati
         }
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
-        vlGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsForceEnable)) {
+        vkuGetLayerSettingValue(layer_setting_set, kLayerSettingsForceEnable, layer_settings->force_enable);
     }
 
-    if (vlHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
-        vlGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
+    if (vkuHasLayerSetting(layer_setting_set, kLayerSettingsCustomSTypeInfo)) {
+        vkuGetLayerSettingValues(layer_setting_set, kLayerSettingsCustomSTypeInfo, custom_stype_info);
     }
 
-    vlDestroyLayerSettingSet(layer_setting_set, pAllocator);
+    vkuDestroyLayerSettingSet(layer_setting_set, pAllocator);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
             "install_dir": "Vulkan-Headers/build/install",
-            "commit": "v1.3.264"
+            "commit": "v1.3.265"
         },
         {
             "name": "Vulkan-Utility-Libraries",
@@ -14,7 +14,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "6774c9b24b7e2cd45886911cd71f052824836582",
+            "commit": "v1.3.265",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
No codegen changes from this update, but VUL functions got renamed from vl* to vku*.
