### PR TITLE
tests: Replace custom EXPECT() macro with gtest EXPECT_*()

### DIFF
--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,10 +126,6 @@ static inline const char *vk_result_string(VkResult err) {
         default:
             return "UNKNOWN_RESULT";
     }
-}
-
-static inline void test_error_callback(const char *expr, const char *file, unsigned int line, const char *function) {
-    ADD_FAILURE_AT(file, line) << "Assertion: `" << expr << "'";
 }
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016, 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2020-2022 Valve Corporation
- * Copyright (c) 2015-2016, 2020-2022 LunarG, Inc.
+ * Copyright (c) 2015-2016, 2020-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020-2023 Valve Corporation
+ * Copyright (c) 2015-2016, 2020-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,6 @@ std::vector<Dst> MakeVkHandles(const std::vector<Src *> &v) {
 }
 
 typedef void (*ErrorCallback)(const char *expr, const char *file, unsigned int line, const char *function);
-void set_error_callback(ErrorCallback callback);
 
 class PhysicalDevice;
 class Device;

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -102,9 +102,6 @@ int fopen_s(FILE **pFile, const char *filename, const char *mode) {
 void TestEnvironment::SetUp() {
     // Initialize GLSL to SPV compiler utility
     glslang::InitializeProcess();
-
-    vk_testing::set_error_callback(test_error_callback);
-
     vk::InitDispatchTable();
 }
 


### PR DESCRIPTION
This will automatically report useful information such as non-success error codes.  These are fatal errors but ASSERT_*() won't work right in object methods.