### PR TITLE
tests: Make failed assertions throw

### DIFF
--- a/tests/extension_layer_tests.cpp
+++ b/tests/extension_layer_tests.cpp
@@ -660,19 +660,37 @@ void android_main(struct android_app *app) {
 #endif
 
 #if !defined(ANDROID)
+
+// Makes any failed assertion throw, allowing for graceful cleanup of resources instead of hard aborts
+class ThrowListener : public testing::EmptyTestEventListener {
+    void OnTestPartResult(const testing::TestPartResult &result) override {
+        if (result.type() == testing::TestPartResult::kFatalFailure) {
+            // We need to make sure an exception wasn't already thrown so we dont throw another exception at the same time
+            std::exception_ptr ex = std::current_exception();
+            if (ex) {
+                return;
+            }
+            throw testing::AssertionException(result);
+        }
+    }
+};
+
 int main(int argc, char **argv) {
     int result;
 
 #if defined(_WIN32)
 #if !defined(NDEBUG)
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
     // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_error_mode(_OUT_TO_STDERR);
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
 #endif
 
     // Set VK_LAYER_PATH so that the loader can find the layers
@@ -682,6 +700,7 @@ int main(int argc, char **argv) {
     VkTestFramework::InitArgs(&argc, argv);
 
     ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+    ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
 
     result = RUN_ALL_TESTS();
 


### PR DESCRIPTION
Add a listener to the test framework which throws an exceptions when a test failure occurs. This makes it so that all failed assertions will cause tests to stop executing and begin tearing down, rather than allowing subsequent test code to run, which may put drivers in a bad state.