### PR TITLE
Tests: add portability for sync2 tests

### DIFF
--- a/tests/synchronization2_tests.cpp
+++ b/tests/synchronization2_tests.cpp
@@ -1214,9 +1214,18 @@ TEST_F(Sync2CompatTest, Vulkan10) {
     };
     static const char *layer_name = "VK_LAYER_KHRONOS_synchronization2";
     static const char *ext_name = "VK_KHR_synchronization2";
-    static const VkInstanceCreateInfo inst_info = {
+    static VkInstanceCreateInfo inst_info = {
         VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, NULL, 0, &app_info, 1, &layer_name, 0, NULL,
     };
+
+#ifdef __APPLE__
+    // Must account for portability on Apple platforms
+    std::vector<const char *> requiredExtensions;
+    requiredExtensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    inst_info.enabledExtensionCount = (int)requiredExtensions.size();
+    inst_info.ppEnabledExtensionNames = requiredExtensions.data();
+    inst_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
 
     VkInstance instance;
 


### PR DESCRIPTION
Added portability extension for Apple Platforms to Sync2 tests.