### PR TITLE
Fix sync2 `EnumerateDeviceExtensionProperties` returning incorrect `pPropertyCount` when sync2 is natively supported

### DIFF
--- a/layers/synchronization2.cpp
+++ b/layers/synchronization2.cpp
@@ -109,6 +109,9 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
         }
 
         if (*pPropertyCount < total_count) {
+            // Spec for `vkEnumerateDeviceLayerProperties` says at most `pPropertyCount` structures will be written in this case,
+            // which is the convention we follow for `vkEnumerate*` functions.
+            memcpy(pProperties, properties.data(), *pPropertyCount * sizeof(VkExtensionProperties));
             return VK_INCOMPLETE;
         }
 


### PR DESCRIPTION
When the device natively supports the sync2 extension,
the `EnumerateDeviceExtensionProperties` implementation of the sync2 layer would return into `pPropertyCount` `<the count value down chain> + 1`, same as when the device does NOT natively support it.
This is inconsistent with the layer's behavior because in this case it would not add the extension into `pProperties`.

This resulted in e.g. [`ash::instance::Instance::enumerate_device_extension_properties`](https://docs.rs/ash/latest/ash/struct.Instance.html#method.enumerate_device_extension_properties) returning a `Vec<ExtensionProperties>` with an uninitialized `ExtensionProperties` value at the back.