### PR TITLE
apple: Add version strings to Info.plist

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -96,6 +96,8 @@ foreach(extension_layer ${EXTENSION_LAYERS})
 	if(IOS)
             set_target_properties(${extension_layer} PROPERTIES
 		FRAMEWORK			TRUE
+                MACOSX_FRAMEWORK_BUNDLE_VERSION "${VulkanHeaders_VERSION}"
+                MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${VulkanHeaders_VERSION}"
 		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.${extension_layer}
             )
 	else()


### PR DESCRIPTION
Add Apple appstore required version strings to Info.plist for shader objects and synchronization2 Frameworks.