### PR TITLE
shaderObject: Fix initializing pSampleMask

### DIFF
--- a/layers/shader_object.cpp
+++ b/layers/shader_object.cpp
@@ -2336,6 +2336,7 @@ PartialPipeline CreatePartiallyCompiledPipeline(DeviceData const& deviceData, Vk
             constexpr VkSampleMask all_ones = ~static_cast<VkSampleMask>(0);
             partial_pipeline.draw_state->SetSampleMask(i, all_ones);
         }
+        multisample_state.pSampleMask = partial_pipeline.draw_state->GetSampleMaskPtr();
         partial_pipeline.draw_state->SetAlphaToOneEnable(multisample_state.alphaToOneEnable);
 
         create_info.pDepthStencilState = &depth_stencil_state;


### PR DESCRIPTION
When graphics pipeline library with `VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT` is being created, `VkPipelineMultisampleStateCreateInfo::pSampleMask` should be initialized to the default value, as that is also what the fully compiled pipeline will use and they must match