### PR TITLE
tests: Update android targetSdkVersion from 26 to 33

### DIFF
--- a/tests/android/AndroidManifest.xml
+++ b/tests/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VulkanExtensionLayerTests" android:versionCode="1" android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="26"/>
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="33"/>
     <application android:label="VulkanExtensionLayerTests" android:hasCode="false" android:debuggable='false'>
         <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
         <activity android:name="android.app.NativeActivity" android:label="VulkanExtensionLayerTests" android:exported="true">


### PR DESCRIPTION
There's an issue with Android 14 that will cause a prompt to display on the phone  when trying to run tests. This can cause an issue with CI as the prompt needs to be hit before the tests begin to run. The prompt displays:
```
This app was built for an older version of Android. It might not work
properly and doesn't include the latest security and privacy
protections.  Check for an update, or contact the app's developer
```

Similar issue on VVL and gfxreconstruct:
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8045
- https://github.com/LunarG/gfxreconstruct/pull/1079

tests/android/AndroidManifest.xml:
- Update targetSdkVersion from 26 to 33