### PR TITLE
Fix crash in driver-implemented `vkSetDebugUtilsObjectNameEXT` for `VkSemaphore`'s generated by the extention layer

### DIFF
--- a/utils/log.h
+++ b/utils/log.h
@@ -39,6 +39,10 @@
         }                                                                      \
     } while (0)
 #else  // __ANDROID__
+#ifdef __cplusplus
 #include <cassert>
+#else  // __cplusplus
+#include <assert.h>
+#endif  // __cplusplus
 #define ASSERT(condition) assert(condition);
 #endif


### PR DESCRIPTION
When the device's native driver implements the `VK_EXT_debug_utils` extension,
its `vkSetDebugUtilsObjectNameEXT` would crash for `VkSemaphore`'s generated by the timeline semaphore extension layer.