### PR TITLE
shaderObject: Fix patch control points

### DIFF
--- a/layers/shader_object/generated/shader_object_full_draw_state_struct_members.inl
+++ b/layers/shader_object/generated/shader_object_full_draw_state_struct_members.inl
@@ -223,7 +223,7 @@ private:
     VkBool32 primitive_restart_enable_{};
     VkBool32 rasterizer_discard_enable_{};
     VkBool32 depth_bias_enable_{};
-    uint32_t patch_control_points_{};
+    uint32_t patch_control_points_ = 1;
     VkPolygonMode polygon_mode_{};
     VkSampleCountFlagBits rasterization_samples_{};
     VkBool32 logic_op_enable_{};

--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -1310,7 +1310,6 @@ PartialPipeline CreatePartiallyCompiledPipeline(DeviceData const& deviceData, Vk
         partial_pipeline.draw_state->SetDepthBiasEnable(rasterization_state.depthBiasEnable);
 
         create_info.pTessellationState = &tessellation_state;
-        tessellation_state.patchControlPoints = 1u;
         partial_pipeline.draw_state->SetPatchControlPoints(tessellation_state.patchControlPoints);
     }
 

--- a/scripts/shader_object_generator.py
+++ b/scripts/shader_object_generator.py
@@ -336,7 +336,11 @@ def generate_full_draw_state_struct_members(data):
             generate_getter_and_setter(variable_state_group, variable_data['name'], var_name_private, var_type, length)
         else:
             # value member
-            member_variables_section.append(f'{var_type} {var_name_private}{{}};\n')
+            if var_name_private == "patch_control_points_":
+                member_variables_section.append(f'{var_type} {var_name_private} = 1;\n')
+            else:
+                member_variables_section.append(f'{var_type} {var_name_private}{{}};\n')
+
             if var_type == 'VkFormat':
                 comparison_code.append(f'if (!(o.{var_name_private} == {var_name_private}) && (!o.dynamic_rendering_unused_attachments_ || o.{var_name_private} != VK_FORMAT_UNDEFINED) && (!dynamic_rendering_unused_attachments_ || {var_name_private} != VK_FORMAT_UNDEFINED)) {{\n')
             elif var_name_private == 'num_color_attachments_':


### PR DESCRIPTION
Closes #415

This is required in the case when the implementation supports `VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT` and `vkCmdSetPatchControlPointsEXT` is not intercepted, so this value is never changed.