### PR TITLE
shaderObject: Fix null pointer dereference if privateData or dynamicRendering not supported

### DIFF
--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -2034,7 +2034,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevi
 #include "generated/shader_object_create_device_feature_structs.inl"
         device_features.pNext = appended_features_chain;
         instance_vtable.GetPhysicalDeviceFeatures2(physicalDevice, &device_features);
-        if (dynamic_rendering_ptr->dynamicRendering == VK_FALSE) {
+        if (!dynamic_rendering_ptr || dynamic_rendering_ptr->dynamicRendering == VK_FALSE) {
             // Dynamic rendering is required
             vku::FreePnextChain(device_next_chain);
             allocator.pfnFree(allocator.pUserData, enabled_extension_names);
@@ -2064,7 +2064,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevi
         };
 
         // Append to deep-copied pNext chain
-        if (private_data_ptr->privateData == VK_TRUE) {
+        if (private_data_ptr && private_data_ptr->privateData == VK_TRUE) {
             last->pNext = reinterpret_cast<VkBaseOutStructure*>(&reserved_private_data_slot);
         } else {
             last->pNext = appended_features_chain;


### PR DESCRIPTION
See initialization flow: https://github.com/KhronosGroup/Vulkan-ExtensionLayer/blob/main/layers/shader_object/generated/shader_object_create_device_feature_structs.inl