### PR TITLE
shaderObject: Fix appending physical device features

### DIFF
--- a/layers/shader_object/generated/shader_object_create_device_feature_structs.inl
+++ b/layers/shader_object/generated/shader_object_create_device_feature_structs.inl
@@ -20,9 +20,11 @@
 VkBaseOutStructure* appended_features_chain = nullptr;
 VkBaseOutStructure* appended_features_chain_last = nullptr;
 
+auto vulkan_1_3_ptr = reinterpret_cast<VkPhysicalDeviceVulkan13Features*>(FindStructureInChain(device_next_chain, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES));
+
 auto dynamic_rendering_ptr = reinterpret_cast<VkPhysicalDeviceDynamicRenderingFeatures*>(FindStructureInChain(device_next_chain, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES));
 VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_local{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES};
-if (dynamic_rendering_ptr == nullptr && (physical_device_data->supported_additional_extensions & DYNAMIC_RENDERING) != 0) {
+if (vulkan_1_3_ptr == nullptr && dynamic_rendering_ptr == nullptr && (physical_device_data->supported_additional_extensions & DYNAMIC_RENDERING) != 0) {
     dynamic_rendering_ptr = &dynamic_rendering_local;
     if (appended_features_chain_last == nullptr) {
         appended_features_chain = (VkBaseOutStructure*)dynamic_rendering_ptr;
@@ -34,7 +36,7 @@ if (dynamic_rendering_ptr == nullptr && (physical_device_data->supported_additio
 }
 auto private_data_ptr = reinterpret_cast<VkPhysicalDevicePrivateDataFeaturesEXT*>(FindStructureInChain(device_next_chain, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES));
 VkPhysicalDevicePrivateDataFeaturesEXT private_data_local{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES};
-if (private_data_ptr == nullptr && (physical_device_data->supported_additional_extensions & PRIVATE_DATA) != 0) {
+if (vulkan_1_3_ptr == nullptr && private_data_ptr == nullptr && (physical_device_data->supported_additional_extensions & PRIVATE_DATA) != 0) {
     private_data_ptr = &private_data_local;
     if (appended_features_chain_last == nullptr) {
         appended_features_chain = (VkBaseOutStructure*)private_data_ptr;

--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -2206,7 +2206,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevi
 #include "generated/shader_object_create_device_feature_structs.inl"
         device_features.pNext = appended_features_chain;
         instance_vtable.GetPhysicalDeviceFeatures2(physicalDevice, &device_features);
-        if (!dynamic_rendering_ptr || dynamic_rendering_ptr->dynamicRendering == VK_FALSE) {
+        if ((!vulkan_1_3_ptr || vulkan_1_3_ptr->dynamicRendering == VK_FALSE) && (!dynamic_rendering_ptr || dynamic_rendering_ptr->dynamicRendering == VK_FALSE)) {
             // Dynamic rendering is required
             vku::FreePnextChain(device_next_chain);
             allocator.pfnFree(allocator.pUserData, enabled_extension_names);
@@ -2236,7 +2236,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevi
         };
 
         // Append to deep-copied pNext chain
-        if (private_data_ptr && private_data_ptr->privateData == VK_TRUE) {
+        if ((vulkan_1_3_ptr && vulkan_1_3_ptr->privateData == VK_TRUE) || (private_data_ptr && private_data_ptr->privateData == VK_TRUE)) {
             last->pNext = reinterpret_cast<VkBaseOutStructure*>(&reserved_private_data_slot);
         } else {
             last->pNext = appended_features_chain;

--- a/scripts/shader_object_data.json
+++ b/scripts/shader_object_data.json
@@ -4,7 +4,8 @@
             "name": "DYNAMIC_RENDERING",
             "extension_name_macro": "VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME",
             "feature_struct": "VkPhysicalDeviceDynamicRenderingFeatures",
-            "feature_struct_stype": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES"
+            "feature_struct_stype": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES",
+            "promoted_to": "1_3"
         },
         {
             "name": "MAINTENANCE_2",
@@ -14,7 +15,8 @@
             "name": "PRIVATE_DATA",
             "extension_name_macro": "VK_EXT_PRIVATE_DATA_EXTENSION_NAME",
             "feature_struct": "VkPhysicalDevicePrivateDataFeaturesEXT",
-            "feature_struct_stype": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES"
+            "feature_struct_stype": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES",
+            "promoted_to": "1_3"
         },
         {
             "name": "EXTENDED_DYNAMIC_STATE_1",

--- a/scripts/shader_object_generator.py
+++ b/scripts/shader_object_generator.py
@@ -189,6 +189,7 @@ def generate_create_device_feature_structs(data):
 
     out_file.write('VkBaseOutStructure* appended_features_chain = nullptr;\n')
     out_file.write('VkBaseOutStructure* appended_features_chain_last = nullptr;\n\n')
+    out_file.write('auto vulkan_1_3_ptr = reinterpret_cast<VkPhysicalDeviceVulkan13Features*>(FindStructureInChain(device_next_chain, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES));\n\n')
 
     # Performance could be improved, this is a naive implementation
 
@@ -201,9 +202,10 @@ def generate_create_device_feature_structs(data):
         enum_name = extension['name']
         var_name = extension['name'].lower()
         initializer = '{' + extension['feature_struct_stype'] + '}'
+        promoted_struct = f'vulkan_{extension['promoted_to']}_ptr == nullptr && ' if 'promoted_to' in extension else ''
         out_file.write(f'auto {var_name}_ptr = reinterpret_cast<{struct_name}*>(FindStructureInChain(device_next_chain, {sType}));\n')
         out_file.write(f'{struct_name} {var_name}_local{initializer};\n')
-        out_file.write(f'if ({var_name}_ptr == nullptr && (physical_device_data->supported_additional_extensions & {enum_name}) != 0) {{\n')
+        out_file.write(f'if ({promoted_struct}{var_name}_ptr == nullptr && (physical_device_data->supported_additional_extensions & {enum_name}) != 0) {{\n')
         out_file.write(f'    {var_name}_ptr = &{var_name}_local;\n')
         out_file.write(f'    if (appended_features_chain_last == nullptr) {{\n')
         out_file.write(f'        appended_features_chain = (VkBaseOutStructure*){var_name}_ptr;\n')


### PR DESCRIPTION
If `VkPhysicalDeviceVulkan13Features` is used then `VkPhysicalDeviceDynamicRenderingFeatures` and `VkPhysicalDevicePrivateDataFeaturesEXT` cannot be included