### PR TITLE
decompression: Report features and properties

### DIFF
--- a/layers/decompression/decompression.h
+++ b/layers/decompression/decompression.h
@@ -91,6 +91,8 @@ struct InstanceData {
         DECLARE_HOOK(EnumerateInstanceExtensionProperties);
         DECLARE_HOOK(GetPhysicalDeviceProperties2);
         DECLARE_HOOK(GetPhysicalDeviceFeatures2);
+        DECLARE_HOOK(GetPhysicalDeviceProperties2KHR);
+        DECLARE_HOOK(GetPhysicalDeviceFeatures2KHR);
         DECLARE_HOOK(GetPhysicalDeviceProperties);
         DECLARE_HOOK(GetPhysicalDeviceMemoryProperties);
     } vtable;


### PR DESCRIPTION
The existing implementation has hooks for
vkGetPhysicalDeviceFeatures2 and vkGetPhysicalDeviceProperties2 that just call to the underlying implementation. We need to know what the underlying implementation supports to determine if the layer should activate, but if the underlying implementation does not support the decompression extension, the existing hooks won't report the decompression features and properties, even when the layer is active.

This commit moves the feature + property queries for the underlying implementation to vkGetPhysicalDeviceFeatures2Internal and GetPhysicalDeviceProperties2Internal so the hooks for vkGetPhysicalDeviceFeatures2 and vkGetPhysicalDeviceProperties2 can properly report decompression attributes when the extension implementation is provided by the layer.

The additional information enabled by this commit
is required when using the layer with vkd3d-proton; see https://github.com/HansKristian-Work/vkd3d-proton/blob/adba7fd4ecedcf08efbb778d2c21ce6d58951496/libs/vkd3d/meta_commands.c#L160-L162

Hooks for vkGetPhysicalDeviceProperties2KHR and
vkGetPhysicalDeviceFeatures2KHR are added as well.