### PR TITLE
timeline_semaphore: Use correct GetDeviceProcAddr

### DIFF
--- a/layers/timeline_semaphore.c
+++ b/layers/timeline_semaphore.c
@@ -395,6 +395,8 @@ static void fill_device_vtable(struct vulkan_vtable *vtable, VkDevice device,
 #define ENTRY_POINT(name) vtable->name = (PFN_vk##name) get_proc_addr(device, "vk"#name);
     ENTRY_POINTS
 #undef ENTRY_POINT
+    // Fixup the GetDeviceProcAddr as otherwise we replace our own GDPA with the GDPA of the next layer
+    vtable->GetDeviceProcAddr = get_proc_addr;
 }
 
 /**/


### PR DESCRIPTION
The implementation of fill_device_vtable would set the vkGetDeviceProcAddr to the value of the next layer's instead of itself, so calls to timeline semaphore's GetDeviceProcAddr would skip any layer after itself.