### PR TITLE
layers: Add missing structures to switch

### DIFF
--- a/layers/timeline_semaphore.c
+++ b/layers/timeline_semaphore.c
@@ -2168,6 +2168,10 @@ static size_t vk_device_create_info_type_size(
         return sizeof(VkPhysicalDeviceDepthClipEnableFeaturesEXT);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
         return sizeof(VkPhysicalDeviceDescriptorIndexingFeatures);
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
+        return sizeof(VkPhysicalDeviceDynamicRenderingFeatures);
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR:
+        return sizeof(VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
         return sizeof(VkPhysicalDeviceExclusiveScissorFeaturesNV);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
@@ -2238,6 +2242,8 @@ static size_t vk_device_create_info_type_size(
         return sizeof(VkPhysicalDeviceShadingRateImageFeaturesNV);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT:
         return sizeof(VkPhysicalDeviceSubgroupSizeControlFeaturesEXT);
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
+        return sizeof(VkPhysicalDeviceSynchronization2Features);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
         return sizeof(VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT:
@@ -2256,6 +2262,8 @@ static size_t vk_device_create_info_type_size(
         return sizeof(VkPhysicalDeviceVulkan11Features);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
         return sizeof(VkPhysicalDeviceVulkan12Features);
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
+        return sizeof(VkPhysicalDeviceVulkan13Features);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
         return sizeof(VkPhysicalDeviceVulkanMemoryModelFeatures);
     case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:


### PR DESCRIPTION
Add vk_device_create_info_type_size support for anumber of missing structures:
- VkPhysicalDeviceDynamicRenderingFeatures
- VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR
- VkPhysicalDeviceSynchronization2Features
- VkPhysicalDeviceVulkan13Features