### PR TITLE
layers: Remove C++ exceptions

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2024 Valve Corporation
-# Copyright (c) 2014-2024 LunarG, Inc.
+# Copyright (c) 2014-2025 Valve Corporation
+# Copyright (c) 2014-2025 LunarG, Inc.
 # Copyright (c) 2019      Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,16 @@ foreach(extension_layer ${EXTENSION_LAYERS})
     lunarg_target_compiler_configurations(${extension_layer} ${BUILD_WERROR})
     target_include_directories(${extension_layer} PRIVATE .)
     target_link_libraries(${extension_layer} PRIVATE VkExtLayer_utils Vulkan::LayerSettings Vulkan::SafeStruct Vulkan::UtilityHeaders)
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${extension_layer} PRIVATE
+            -fno-exceptions
+        )
+    elseif(MSVC)
+        target_compile_options(${extension_layer} PRIVATE
+            /EHsc- # No-Exceptions
+        )
+    endif()
 
     if(MSVC)
         target_link_options(${extension_layer} PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/${extension_layer}.def)

--- a/utils/allocator.h
+++ b/utils/allocator.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2020-2021 The Khronos Group Inc.
- * Copyright (c) 2020-2021 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,7 @@ class Allocator {
 
     T* allocate(size_t num, const void* = 0) {
         T* result = reinterpret_cast<T*>(alloc->pfnAllocation(alloc->pUserData, num * sizeof(T), alignof(T), AllocScope));
-        if (result == nullptr) {
-            throw std::bad_alloc();
-        }
+        assert(result);
         return result;
     }
 


### PR DESCRIPTION
From asking around, seems no one could find a reason why we had exceptions here and only reasons why we should not have them.

I was surprised to find these here and we already return `VkResult` where possible