### PR TITLE
shaderObject: Fix nuisance depth/stencil format inconsistency

### DIFF
--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -2771,12 +2771,16 @@ static VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(VkCommandBuffer commandBuffe
         VkImageView view = pRenderingInfo->pDepthAttachment->imageView;
         VkFormat format = view == VK_NULL_HANDLE ? VK_FORMAT_UNDEFINED : cmd_data->device_data->image_view_format_map.Get(view);
         state->SetDepthAttachmentFormat(format);
+    } else {
+        state->SetDepthAttachmentFormat(VK_FORMAT_UNDEFINED);
     }
 
     if (pRenderingInfo->pStencilAttachment) {
         VkImageView view = pRenderingInfo->pStencilAttachment->imageView;
         VkFormat format = view == VK_NULL_HANDLE ? VK_FORMAT_UNDEFINED : cmd_data->device_data->image_view_format_map.Get(view);
         state->SetStencilAttachmentFormat(format);
+    } else {
+        state->SetStencilAttachmentFormat(VK_FORMAT_UNDEFINED);
     }
     cmd_data->device_data->vtable.CmdBeginRendering(commandBuffer, pRenderingInfo);
 }


### PR DESCRIPTION
This PR fixes a bug which causes a nuisance validation error whenever a depth-only or stencil-only format is used.