### PR TITLE
shaderObject: Add support for VK_EXT_descriptor_heap

### DIFF
--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -33,6 +33,7 @@
 #include <vulkan/vk_layer.h>
 #include <vulkan/layer/vk_layer_settings.hpp>
 #include <vulkan/utility/vk_safe_struct.hpp>
+#include <vulkan/utility/vk_struct_helper.hpp>
 
 #include "log.h"
 #include "vk_api_hash.h"
@@ -188,6 +189,7 @@ struct InstanceData {
     VkInstance            instance;
     VkPhysicalDevice*     physical_devices;
     uint32_t              physical_device_count;
+    uint32_t              api_version;
     LayerSettings         layer_settings;
 };
 
@@ -310,6 +312,99 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
         aligned_memory.Add<VkSpecializationMapEntry>(createInfo.pSpecializationInfo->mapEntryCount);
     }
 
+    bool use_descriptor_heap = (createInfo.flags & VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT);
+    const VkShaderDescriptorSetAndBindingMappingInfoEXT* binding_mapping =
+        vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(createInfo.pNext);
+
+    if (use_descriptor_heap && binding_mapping && binding_mapping->mappingCount > 0) {
+        aligned_memory.Add<VkDescriptorSetAndBindingMappingEXT>(binding_mapping->mappingCount);
+        auto update_sampler_info = [&](const VkSamplerCreateInfo* pEmbeddedSampler) {
+            if (pEmbeddedSampler) {
+                aligned_memory.Add<VkSamplerCreateInfo>();
+                auto* pNext = reinterpret_cast<const VkBaseInStructure*>(pEmbeddedSampler->pNext);
+                while (pNext) {
+                    switch (pNext->sType) {
+                        case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT: {
+                            aligned_memory.Add<VkDebugUtilsObjectNameInfoEXT>();
+                            auto* pObject = reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT*>(pNext);
+                            aligned_memory.Add<char>(std::strlen(pObject->pObjectName) + 1);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT: {
+                            // This should not occur since VK_EXT_descriptor_buffer is superceded by VK_EXT_descriptor_heap
+                            ASSERT(false);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM: {
+                            aligned_memory.Add<VkSamplerBlockMatchWindowCreateInfoQCOM>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT: {
+                            aligned_memory.Add<VkSamplerBorderColorComponentMappingCreateInfoEXT>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM: {
+                            aligned_memory.Add<VkSamplerCubicWeightsCreateInfoQCOM>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT: {
+                            aligned_memory.Add<VkSamplerCustomBorderColorCreateInfoEXT>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_INDEX_CREATE_INFO_EXT: {
+                            aligned_memory.Add<VkSamplerCustomBorderColorIndexCreateInfoEXT>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO: {
+                            aligned_memory.Add<VkSamplerReductionModeCreateInfo>();
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO: {
+                            aligned_memory.Add<VkSamplerYcbcrConversionInfo>();
+                            break;
+                        }
+                        default: {
+                            ASSERT(false);
+                            break;
+                        }
+                    }
+
+                    pNext = pNext->pNext;
+                }
+            }
+        };
+        for (uint32_t idx = 0; idx < binding_mapping->mappingCount; ++idx) {
+            auto& binding = binding_mapping->pMappings[idx];
+            switch (binding.source) {
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT:
+                    update_sampler_info(binding.sourceData.constantOffset.pEmbeddedSampler);
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT:
+                    update_sampler_info(binding.sourceData.pushIndex.pEmbeddedSampler);
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT:
+                    update_sampler_info(binding.sourceData.indirectIndex.pEmbeddedSampler);
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT:
+                    update_sampler_info(binding.sourceData.indirectIndexArray.pEmbeddedSampler);
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT:
+                    update_sampler_info(binding.sourceData.shaderRecordIndex.pEmbeddedSampler);
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT:
+                    break;
+                default:
+                    ASSERT(false);
+                    break;
+            }
+        }
+    }
+
     aligned_memory.Allocate(allocator, VkSystemAllocationScope::VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     if (!aligned_memory) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -328,6 +423,8 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
     if (createInfo.flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) {
         shader->flags |= VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
     }
+
+    shader->use_descriptor_heap = use_descriptor_heap;
 
     // Copy data over from create info struct
 
@@ -352,6 +449,133 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
 
         aligned_memory.CopyStruct(shader->specialization_info.pMapEntries, shader->specialization_info.mapEntryCount,
                                   createInfo.pSpecializationInfo->pMapEntries, createInfo.pSpecializationInfo->mapEntryCount);
+    }
+
+    if (use_descriptor_heap && binding_mapping && binding_mapping->mappingCount > 0) {
+        aligned_memory.CopyStruct<VkDescriptorSetAndBindingMappingEXT>(shader->descriptor_set_and_binding_mapping_ptr,
+                                                                       shader->num_descriptor_set_and_binding_mappings,
+                                                                       binding_mapping->pMappings, binding_mapping->mappingCount);
+        auto copy_sampler_info = [&](VkSamplerCreateInfo** pEmbeddedSampler) {
+            if (*pEmbeddedSampler) {
+                auto* pOutEmbeddedSampler = aligned_memory.GetNextAlignedPtr<VkSamplerCreateInfo>();
+                *pOutEmbeddedSampler = **pEmbeddedSampler;
+                auto* pInNext = reinterpret_cast<const VkBaseInStructure*>((*pEmbeddedSampler)->pNext);
+                auto* pOutNext = reinterpret_cast<VkBaseOutStructure*>(pOutEmbeddedSampler);
+
+                while (pInNext) {
+                    switch (pInNext->sType) {
+                        case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkDebugUtilsObjectNameInfoEXT>();
+                            auto* pOrigObject = reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT*>(pInNext);
+                            *pObject = *pOrigObject;
+                            pObject->pObjectName = aligned_memory.GetNextAlignedPtr<char>(std::strlen(pObject->pObjectName) + 1);
+                            std::strcpy(const_cast<char*>(pObject->pObjectName), pOrigObject->pObjectName);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT: {
+                            // This should not occur since VK_EXT_descriptor_buffer is superceded by VK_EXT_descriptor_heap
+                            ASSERT(false);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerBlockMatchWindowCreateInfoQCOM>();
+                            *pObject = *reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerBorderColorComponentMappingCreateInfoEXT>();
+                            *pObject = *reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerCubicWeightsCreateInfoQCOM>();
+                            *pObject = *reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerCustomBorderColorCreateInfoEXT>();
+                            *pObject = *reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_INDEX_CREATE_INFO_EXT: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerCustomBorderColorIndexCreateInfoEXT>();
+                            *pObject = *reinterpret_cast<const VkSamplerCustomBorderColorIndexCreateInfoEXT*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerReductionModeCreateInfo>();
+                            *pObject = *reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO: {
+                            auto* pObject = aligned_memory.GetNextAlignedPtr<VkSamplerYcbcrConversionInfo>();
+                            *pObject = *reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(pInNext);
+                            pObject->pNext = nullptr;
+                            pOutNext->pNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            pOutNext = reinterpret_cast<VkBaseOutStructure*>(pObject);
+                            break;
+                        }
+                        default: {
+                            ASSERT(false);
+                            break;
+                        }
+                    }
+                    pInNext = pInNext->pNext;
+                }
+            }
+        };
+
+        for (uint32_t idx = 0; idx < binding_mapping->mappingCount; ++idx) {
+            auto& binding = shader->descriptor_set_and_binding_mapping_ptr[idx];
+            switch (binding.source) {
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT:
+                    copy_sampler_info(const_cast<VkSamplerCreateInfo**>(&binding.sourceData.constantOffset.pEmbeddedSampler));
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT:
+                    copy_sampler_info(const_cast<VkSamplerCreateInfo**>(&binding.sourceData.pushIndex.pEmbeddedSampler));
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT:
+                    copy_sampler_info(const_cast<VkSamplerCreateInfo**>(&binding.sourceData.indirectIndex.pEmbeddedSampler));
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT:
+                    copy_sampler_info(const_cast<VkSamplerCreateInfo**>(&binding.sourceData.indirectIndexArray.pEmbeddedSampler));
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT:
+                    copy_sampler_info(const_cast<VkSamplerCreateInfo**>(&binding.sourceData.shaderRecordIndex.pEmbeddedSampler));
+                    break;
+                case VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT:
+                case VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT:
+                    break;
+                default:
+                    ASSERT(false);
+                    break;
+            }
+        }
     }
 
     // Create shader module from SPIR-V
@@ -400,20 +624,26 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
     } else if (createInfo.stage & VK_SHADER_STAGE_COMPUTE_BIT) {
         // Compute shaders do not require any additional data for a pipeline to be created
 
-        result = CreatePipelineLayoutForShader(deviceData, allocator, shader);
-        if (result != VK_SUCCESS) {
-            return result;
+        if (!shader->use_descriptor_heap) {
+            result = CreatePipelineLayoutForShader(deviceData, allocator, shader);
+            if (result != VK_SUCCESS) {
+                return result;
+            }
         }
+
+        VkShaderDescriptorSetAndBindingMappingInfoEXT mapping = {};
+        shader->FillBindingAndMappingStruct(mapping);
 
         VkPipelineShaderStageCreateInfo compute_stage{
             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-            nullptr,
+            &mapping,
             shader->flags,
             shader->stage,
             shader->shader_module,
             shader->name,
             shader->specialization_info_ptr
         };
+
         VkComputePipelineCreateInfo compute_pipeline_create_info{
             VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
             nullptr,
@@ -424,6 +654,17 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
         if (createInfo.flags & VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT) {
             compute_pipeline_create_info.flags |= VK_PIPELINE_CREATE_DISPATCH_BASE;
         }
+
+        VkPipelineCreateFlags2CreateInfo pipeline_create_flag2_create_info = {};
+        if (shader->use_descriptor_heap) {
+            pipeline_create_flag2_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+            pipeline_create_flag2_create_info.flags = compute_pipeline_create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+            compute_pipeline_create_info.pNext = &pipeline_create_flag2_create_info;
+        }
+
+        ASSERT((pipeline_create_flag2_create_info.flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT) ||
+               compute_pipeline_create_info.layout != VK_NULL_HANDLE);
+
         result = vtable.CreateComputePipelines(deviceData.device, shader->cache, 1, &compute_pipeline_create_info, &allocator, &shader->partial_pipeline.pipeline);
     }
 
@@ -813,9 +1054,13 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
     // gather shaders
     uint32_t num_stages = 0;
     VkPipelineShaderStageCreateInfo stages[NUM_SHADERS] = {};
+    VkShaderDescriptorSetAndBindingMappingInfoEXT binding_mappings[NUM_SHADERS] = {};
     Shader* vertex_or_mesh_shader = nullptr;
 
     VkShaderStageFlags present_stages = 0;
+
+    VkPipelineCreateFlags2CreateInfo pipeline_create_flag2_create_info = {};
+    pipeline_create_flag2_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
 
     for (uint32_t shader_type = 0; shader_type < NUM_SHADERS; ++shader_type) {
         Shader* shader = state->GetComparableShader(shader_type).GetShaderPtr();
@@ -828,11 +1073,17 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
 
         VkPipelineShaderStageCreateInfo stage = {};
         stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage.pNext = &binding_mappings[num_stages];
         stage.flags = shader->flags;
         stage.module = shader->shader_module;
         stage.pName = shader->name;
         stage.stage = shader->stage;
         stage.pSpecializationInfo = shader->specialization_info_ptr;
+
+        shader->FillBindingAndMappingStruct(binding_mappings[num_stages]);
+        if (shader->use_descriptor_heap) {
+            pipeline_create_flag2_create_info.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        }
 
         switch (shader_type) {
             case VERTEX_SHADER:
@@ -851,11 +1102,11 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
     ASSERT(vertex_or_mesh_shader != nullptr);
 
     VkPipelineLayout pipeline_layout = vertex_or_mesh_shader->pipeline_layout;
-    if (pipeline_layout == VK_NULL_HANDLE) {
-        pipeline_layout = cmd_data.last_seen_pipeline_layout_;
-    }
-    if (pipeline_layout == VK_NULL_HANDLE) {
-        pipeline_layout = cmd_data.device_data->dummy_pipeline_layout;
+    if (pipeline_create_flag2_create_info.flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT) {
+        pipeline_layout = VK_NULL_HANDLE;
+    } else if (pipeline_layout == VK_NULL_HANDLE) {
+        pipeline_layout =
+            cmd_data.last_seen_pipeline_layout_ ? cmd_data.last_seen_pipeline_layout_ : cmd_data.device_data->dummy_pipeline_layout;
     }
 
     const uint32_t num_color_attachments = (device_data.enabled_extensions & DYNAMIC_RENDERING_UNUSED_ATTACHMENTS) ? device_data.properties.limits.maxColorAttachments : state->GetNumColorAttachments();
@@ -1089,6 +1340,13 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
         prev_next = prev_next->pNext;
     };
 
+    if (pipeline_create_flag2_create_info.flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT) {
+        // Avoid future issues if create_info.flags becomes non-zero
+        pipeline_create_flag2_create_info.flags |= create_info.flags;
+
+        append_to_chain(&pipeline_create_flag2_create_info);
+    }
+
     if (device_data.enabled_extensions & DYNAMIC_RENDERING_UNUSED_ATTACHMENTS) {
         VkFormat lastFormat = VK_FORMAT_R8G8B8A8_UNORM;
         for (uint32_t i = 0; i < num_color_attachments; ++i) {
@@ -1187,6 +1445,9 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
         }
     }
 
+    ASSERT((pipeline_create_flag2_create_info.flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT) ||
+           create_info.layout != VK_NULL_HANDLE);
+
     VkPipeline pipeline;
     VkResult result = cmd_data.device_data->vtable.CreateGraphicsPipelines(
         cmd_data.device_data->device, vertex_or_mesh_shader->cache, 1, &create_info, nullptr, &pipeline);
@@ -1198,7 +1459,7 @@ static VkPipeline CreateGraphicsPipelineForCommandBufferState(CommandBufferData&
     return pipeline;
 }
 
-enum PipelineCreationFlagBits { INCLUDE_COLOR = 0x1, INCLUDE_DEPTH = 0x2 };
+enum PipelineCreationFlagBits { INCLUDE_COLOR = 0x1, INCLUDE_DEPTH = 0x2, USE_DESCRIPTOR_HEAP = 0x4 };
 using PipelineCreationFlags = uint32_t;
 
 void AddGraphicsPipelineToCache(DeviceData const& deviceData, VkAllocationCallbacks allocator, VkPipelineCache cache,
@@ -1340,7 +1601,17 @@ void AddGraphicsPipelineToCache(DeviceData const& deviceData, VkAllocationCallba
         VK_NULL_HANDLE,
         -1
     };
- 
+
+    VkPipelineCreateFlags2CreateInfo pipeline_create_flag2_create_info = {};
+    if (options & PipelineCreationFlagBits::USE_DESCRIPTOR_HEAP) {
+        pipeline_create_flag2_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        pipeline_create_flag2_create_info.flags = create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        rendering_info.pNext = &pipeline_create_flag2_create_info;
+    }
+
+    ASSERT((pipeline_create_flag2_create_info.flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT) ||
+           create_info.layout != VK_NULL_HANDLE);
+
     VkPipeline temp_pipeline;
     VkResult result = vtable.CreateGraphicsPipelines(deviceData.device, cache, 1, &create_info, nullptr, &temp_pipeline);
     if (result == VK_SUCCESS) {
@@ -1360,6 +1631,9 @@ PartialPipeline CreatePartiallyCompiledPipeline(DeviceData const& deviceData, Vk
            (VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT | VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT));
 
     VkPipelineShaderStageCreateInfo stages[NUM_SHADERS];
+    VkShaderDescriptorSetAndBindingMappingInfoEXT binding_mappings[NUM_SHADERS] = {};
+    bool use_descriptor_heap = false;
+
     VkGraphicsPipelineLibraryCreateInfoEXT gpl_create_info{
         VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT,
         nullptr,
@@ -1370,13 +1644,17 @@ PartialPipeline CreatePartiallyCompiledPipeline(DeviceData const& deviceData, Vk
         auto shader = ppShaders[i];
         stages[i] = {
             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-            nullptr,
+            &binding_mappings[i],
             shader->flags,
             shader->stage,
             shader->shader_module,
             shader->name,
             shader->specialization_info_ptr
         };
+
+        shader->FillBindingAndMappingStruct(binding_mappings[i]);
+        use_descriptor_heap = use_descriptor_heap || shader->use_descriptor_heap;
+
         shader_stage_flags |= shader->stage;
         switch (shader->stage) {
             case VK_SHADER_STAGE_VERTEX_BIT:
@@ -1515,6 +1793,15 @@ PartialPipeline CreatePartiallyCompiledPipeline(DeviceData const& deviceData, Vk
     create_info.layout = layout;
     create_info.basePipelineIndex = -1;
 
+    VkPipelineCreateFlags2CreateInfo pipeline_create_flag2_create_info = {};
+    if (use_descriptor_heap) {
+        pipeline_create_flag2_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO;
+        pipeline_create_flag2_create_info.flags = create_info.flags | VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+        gpl_create_info.pNext = &pipeline_create_flag2_create_info;
+    }
+
+    ASSERT(use_descriptor_heap || create_info.layout != VK_NULL_HANDLE);
+
     VkResult result = deviceData.vtable.CreateGraphicsPipelines(deviceData.device, cache, 1, &create_info, &allocator, &partial_pipeline.pipeline);
     ASSERT(result == VK_SUCCESS);
     UNUSED(result);
@@ -1537,11 +1824,13 @@ static VkResult PopulateCachesForShaders(DeviceData const& deviceData, VkAllocat
             Shader* vertex_or_mesh_shader = nullptr;
             Shader* fragment_shader = nullptr;
             uint32_t tess_shaders = 0;
+            bool use_descriptor_heap = false;
             for (uint32_t i = 0; i < shaderCount; ++i) {
                 auto shader = *reinterpret_cast<Shader**>(&pShaders[i]);
                 if (shader->stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT || shader->stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
                     ++tess_shaders;
                 }
+                use_descriptor_heap = use_descriptor_heap || shader->use_descriptor_heap;
             }
             for (uint32_t i = 0; i < shaderCount; ++i) {
                 auto shader = *reinterpret_cast<Shader**>(&pShaders[i]);
@@ -1582,7 +1871,10 @@ static VkResult PopulateCachesForShaders(DeviceData const& deviceData, VkAllocat
             }
 
             ASSERT((!vertex_or_mesh_shader && !fragment_shader) || cache_for_linked_shaders != VK_NULL_HANDLE);
-            ASSERT((!vertex_or_mesh_shader && !fragment_shader) || layout_for_linked_shaders != VK_NULL_HANDLE);
+            ASSERT((!vertex_or_mesh_shader && !fragment_shader) || use_descriptor_heap ||
+                   layout_for_linked_shaders != VK_NULL_HANDLE);
+            ASSERT(!vertex_or_mesh_shader || !fragment_shader ||
+                   vertex_or_mesh_shader->use_descriptor_heap == fragment_shader->use_descriptor_heap);
 
             if (vertex_or_mesh_shader) {
                 vertex_or_mesh_shader->partial_pipeline = CreatePartiallyCompiledPipeline(
@@ -1628,9 +1920,11 @@ static VkResult PopulateCachesForShaders(DeviceData const& deviceData, VkAllocat
         bool has_fragment_shader = false;
         bool has_tesc = false;
         bool has_tese = false;
+        PipelineCreationFlags additional_pipeline_create_flags = 0u;
 
         // Gather shaders into stages for pipeline compilation
         VkPipelineShaderStageCreateInfo stages[NUM_SHADERS];
+        VkShaderDescriptorSetAndBindingMappingInfoEXT binding_mappings[NUM_SHADERS] = {};
         uint32_t graphics_shader_count = 0;
         for (uint32_t i = 0; i < shaderCount; ++i) {
             auto shader = *reinterpret_cast<Shader**>(&pShaders[i]);
@@ -1654,9 +1948,14 @@ static VkResult PopulateCachesForShaders(DeviceData const& deviceData, VkAllocat
                     break;
             }
 
+            shader->FillBindingAndMappingStruct(binding_mappings[i]);
+            if (shader->use_descriptor_heap) {
+                additional_pipeline_create_flags |= PipelineCreationFlagBits::USE_DESCRIPTOR_HEAP;
+            }
+
             stages[graphics_shader_count++] = {
                 VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-                nullptr,
+                &binding_mappings[i],
                 shader->flags,
                 shader->stage,
                 shader->shader_module,
@@ -1672,14 +1971,14 @@ static VkResult PopulateCachesForShaders(DeviceData const& deviceData, VkAllocat
 
         AddGraphicsPipelineToCache(deviceData, allocator,
             vertex_or_mesh_shader->cache, vertex_or_mesh_shader->pipeline_layout, graphics_shader_count, stages,
-            PipelineCreationFlagBits::INCLUDE_DEPTH);
+            PipelineCreationFlagBits::INCLUDE_DEPTH | additional_pipeline_create_flags);
         if (has_fragment_shader) {
             AddGraphicsPipelineToCache(deviceData, allocator,
                 vertex_or_mesh_shader->cache, vertex_or_mesh_shader->pipeline_layout, graphics_shader_count, stages,
-                PipelineCreationFlagBits::INCLUDE_COLOR);
+                PipelineCreationFlagBits::INCLUDE_COLOR | additional_pipeline_create_flags);
             AddGraphicsPipelineToCache(deviceData, allocator,
                 vertex_or_mesh_shader->cache, vertex_or_mesh_shader->pipeline_layout, graphics_shader_count, stages,
-                PipelineCreationFlagBits::INCLUDE_DEPTH | PipelineCreationFlagBits::INCLUDE_COLOR);
+                PipelineCreationFlagBits::INCLUDE_DEPTH | PipelineCreationFlagBits::INCLUDE_COLOR | additional_pipeline_create_flags);
         }
     }
 
@@ -1844,6 +2143,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo*
     instance_data->instance = *pInstance;
     instance_data->physical_devices = reinterpret_cast<VkPhysicalDevice*>(instance_data + 1);
     instance_data->physical_device_count = physical_device_count;
+    instance_data->api_version = pCreateInfo->pApplicationInfo ? pCreateInfo->pApplicationInfo->apiVersion : VK_API_VERSION_1_0;
     instance_data->vtable.Initialize(*pInstance, fpGetInstanceProcAddr);
 
     InitLayerSettings(pCreateInfo, pAllocator, &instance_data->layer_settings);
@@ -2127,10 +2427,17 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevi
         break;
     }
     bool shader_object_extension_requested = false;
+    bool descriptor_heap_extension_requested = false;
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; ++i) {
         if (0 ==
             strncmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_SHADER_OBJECT_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE)) {
             shader_object_extension_requested = true;
+        } else if (0 == strncmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME,
+                                VK_MAX_EXTENSION_NAME_SIZE)) {
+            descriptor_heap_extension_requested = true;
+        }
+
+        if (shader_object_extension_requested && descriptor_heap_extension_requested) {
             break;
         }
     }
@@ -2538,7 +2845,9 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(VkDevice device, uint32_t
     }
     if (result == VK_SUCCESS && are_graphics_shaders_linked && (vertex_or_mesh_shader || fragment_shader)) {
         Shader* shader_to_read_layout_from = vertex_or_mesh_shader ? vertex_or_mesh_shader : fragment_shader;
-        result = CreatePipelineLayoutForShader(device_data, allocator, shader_to_read_layout_from);
+        if (!shader_to_read_layout_from->use_descriptor_heap) {
+            result = CreatePipelineLayoutForShader(device_data, allocator, shader_to_read_layout_from);
+        }
     }
     if (result == VK_SUCCESS && !are_graphics_shaders_linked && device_data.graphics_pipeline_library.graphicsPipelineLibrary == VK_TRUE) {
         // Create layout for unlinked shaders that can have partial pipelines created
@@ -2548,7 +2857,9 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(VkDevice device, uint32_t
                 case VK_SHADER_STAGE_VERTEX_BIT:
                 case VK_SHADER_STAGE_MESH_BIT_EXT:
                 case VK_SHADER_STAGE_FRAGMENT_BIT:
-                    result = CreatePipelineLayoutForShader(device_data, allocator, shader);
+                    if (!shader->use_descriptor_heap) {
+                        result = CreatePipelineLayoutForShader(device_data, allocator, shader);
+                    }
                     break;
                 default:
                     break;

--- a/layers/shader_object/shader_object_structs.h
+++ b/layers/shader_object/shader_object_structs.h
@@ -958,6 +958,13 @@ struct Shader {
     uint64_t GetPrivateData(DeviceData const& device_data, VkPrivateDataSlot slot);
     void     SetPrivateData(DeviceData const& device_data, VkPrivateDataSlot slot, uint64_t data);
 
+    inline void FillBindingAndMappingStruct(VkShaderDescriptorSetAndBindingMappingInfoEXT& mapping) const {
+        mapping.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+        mapping.pNext = nullptr;
+        mapping.mappingCount = num_descriptor_set_and_binding_mappings;
+        mapping.pMappings = descriptor_set_and_binding_mapping_ptr;
+    }
+
     uint64_t id;
 
     const char* name;
@@ -997,6 +1004,11 @@ struct Shader {
 
     // If possible, holds a partial pipeline created with graphics pipeline library at create time that may be used to speed up draw time pipeline creation
     PartialPipeline partial_pipeline;
+
+    // Track VK_EXT_descriptor_heap related information
+    bool use_descriptor_heap = false;
+    uint32_t num_descriptor_set_and_binding_mappings = 0;
+    VkDescriptorSetAndBindingMappingEXT* descriptor_set_and_binding_mapping_ptr = nullptr;
 };
 
 class ShaderBinary {

--- a/tests/extension_layer_tests.cpp
+++ b/tests/extension_layer_tests.cpp
@@ -256,6 +256,12 @@ bool VkExtensionLayerTest::CheckShaderObjectSupportAndInitState(bool meshShaders
         shader_object_features.pNext = &mesh_shader_features;
     }
 
+    auto descriptor_heap_features = vku::InitStruct<VkPhysicalDeviceDescriptorHeapFeaturesEXT>();
+    if (DeviceExtensionSupported(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME)) {
+        descriptor_heap_features.pNext = features2.pNext;
+        features2.pNext = &descriptor_heap_features;
+    }
+
     vkGetPhysicalDeviceFeatures2(gpu(), &features2);
     if (!meshShaders) {
         mesh_shader_features.taskShader = VK_FALSE;

--- a/tests/shader_object_tests.cpp
+++ b/tests/shader_object_tests.cpp
@@ -1533,3 +1533,267 @@ TEST_F(ShaderObjectTest, SetDebugName) {
 
     m_errorMonitor->VerifyNotFound();
 }
+
+TEST_F(ShaderObjectTest, DescriptorHeap) {
+    TEST_DESCRIPTION("Test drawing with a vertex and fragment shader using descriptor heap");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    bool skipEmbeddedSamplerDebugUtilTest = !InstanceExtensionSupported(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, 0);
+
+    if (!DeviceExtensionSupported(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME, 0)) {
+        GTEST_SKIP() << kSkipPrefix << " VK_KHR_buffer_device_address not supported, skipping test";
+    } else if (!DeviceExtensionSupported(VK_KHR_MAINTENANCE_5_EXTENSION_NAME, 0)) {
+        GTEST_SKIP() << kSkipPrefix << " VK_KHR_maintenance5 not supported, skipping test";
+    } else if (!DeviceExtensionSupported(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME, 0)) {
+        GTEST_SKIP() << kSkipPrefix << " VK_EXT_descriptor_heap not supported, skipping test";
+    }
+
+    m_device_extension_names.push_back(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    m_device_extension_names.push_back(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
+    m_device_extension_names.push_back(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    if (!CheckShaderObjectSupportAndInitState(false)) {
+        GTEST_SKIP() << kSkipPrefix << " shader object not supported, skipping test";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+
+    m_errorMonitor->ExpectSuccess();
+
+    static const char vertSource[] = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) uniform VSData { vec4 uDrawOffset[4]; };
+        void main() {
+            vec2 pos = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
+            gl_Position = vec4(pos - 0.5f, 0.0f, 1.0f) + uDrawOffset[(gl_VertexIndex / 3) % 4];
+        }
+    )glsl";
+
+    static const char fragSource[] = R"glsl(
+        #version 460
+        layout(set = 0, binding = 1) uniform FSData { vec4 uDrawColor; };
+        layout(location = 0) out vec4 uFragColor;
+        void main(){
+           uFragColor = uDrawColor;
+        }
+    )glsl";
+
+    VkShaderStageFlagBits shaderStages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+
+    std::vector<unsigned int> spv[2];
+    GLSLtoSPV(&m_device->props.limits, VK_SHADER_STAGE_VERTEX_BIT, vertSource, spv[0], false, 0);
+    GLSLtoSPV(&m_device->props.limits, VK_SHADER_STAGE_FRAGMENT_BIT, fragSource, spv[1], false, 0);
+
+    VkSamplerCreateInfo embeddedSampler = vku::InitStructHelper();
+    embeddedSampler.magFilter = VK_FILTER_NEAREST;
+    embeddedSampler.minFilter = VK_FILTER_NEAREST;
+    embeddedSampler.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    embeddedSampler.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    embeddedSampler.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    embeddedSampler.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    embeddedSampler.mipLodBias = 0.0;
+    embeddedSampler.anisotropyEnable = VK_FALSE;
+    embeddedSampler.maxAnisotropy = 1;
+    embeddedSampler.compareOp = VK_COMPARE_OP_NEVER;
+    embeddedSampler.minLod = 0.0;
+    embeddedSampler.maxLod = 0.0;
+    embeddedSampler.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+    embeddedSampler.unnormalizedCoordinates = VK_FALSE;
+
+    VkDebugUtilsObjectNameInfoEXT embeddedSamplerDebugLabel;
+    if (!skipEmbeddedSamplerDebugUtilTest) {
+        embeddedSamplerDebugLabel.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        embeddedSamplerDebugLabel.pNext = nullptr;
+        embeddedSamplerDebugLabel.objectType = VK_OBJECT_TYPE_UNKNOWN;
+        embeddedSamplerDebugLabel.objectHandle = 0ull;
+        embeddedSamplerDebugLabel.pObjectName = "Embedded Sampler";
+
+        embeddedSampler.pNext = &embeddedSamplerDebugLabel;
+    }
+
+    VkDescriptorSetAndBindingMappingEXT mapping[3] = {};
+    mapping[0].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+    mapping[0].pNext = nullptr;
+    mapping[0].firstBinding = 0;
+    mapping[0].bindingCount = 1;
+    mapping[0].descriptorSet = 0;
+    mapping[0].resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT;
+    mapping[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT;
+    mapping[0].sourceData.pushDataOffset = 4 * sizeof(float);
+    mapping[1].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+    mapping[1].pNext = nullptr;
+    mapping[1].firstBinding = 1;
+    mapping[1].bindingCount = 1;
+    mapping[1].descriptorSet = 0;
+    mapping[1].resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT;
+    mapping[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT;
+    mapping[1].sourceData.pushDataOffset = 0;
+    // Unused mapping to test pEmbeddedSampler
+    mapping[2].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+    mapping[2].pNext = nullptr;
+    mapping[2].firstBinding = 2;
+    mapping[2].bindingCount = 1;
+    mapping[2].descriptorSet = 0;
+    mapping[2].resourceMask = VK_SPIRV_RESOURCE_TYPE_SAMPLER_BIT_EXT;
+    mapping[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping[2].sourceData.constantOffset.heapOffset = 0;
+    mapping[2].sourceData.constantOffset.heapArrayStride = 0;
+    mapping[2].sourceData.constantOffset.pEmbeddedSampler = &embeddedSampler;
+    mapping[2].sourceData.constantOffset.samplerHeapOffset = 0;
+    mapping[2].sourceData.constantOffset.samplerHeapArrayStride = 0;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info;
+    mapping_info.sType = VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT;
+    mapping_info.pNext = nullptr;
+    mapping_info.mappingCount = 3;
+    mapping_info.pMappings = mapping;
+
+    VkShaderStageFlagBits unusedShaderStages[] = {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
+                                                  VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT};
+    VkShaderEXT shaders[2];
+    VkShaderCreateInfoEXT createInfos[2];
+    for (uint32_t i = 0; i < 2; ++i) {
+        createInfos[i] = vku::InitStructHelper();
+        createInfos[i].pNext = &mapping_info;
+        createInfos[i].flags = VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT;
+        createInfos[i].stage = shaderStages[i];
+        if (i == 0) {
+            createInfos[i].nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
+        }
+        createInfos[i].codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+        createInfos[i].codeSize = spv[i].size() * sizeof(unsigned int);
+        createInfos[i].pCode = spv[i].data();
+        createInfos[i].pName = "main";
+    }
+
+    vkCreateShadersEXT(m_device->handle(), 2u, createInfos, nullptr, shaders);
+
+    VkBufferObj buffer;
+    buffer.init(*m_device, sizeof(float) * 4u, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferObj vertexBuffer;
+    vertexBuffer.init(*m_device, sizeof(float), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                      VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+
+    VkImageCreateInfo imageInfo = vku::InitStructHelper();
+    imageInfo.flags = 0;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = VK_FORMAT_R32G32B32A32_SFLOAT;
+    imageInfo.extent = {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1};
+    imageInfo.mipLevels = 1u;
+    imageInfo.arrayLayers = 1u;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.queueFamilyIndexCount = 0u;
+    imageInfo.pQueueFamilyIndices = nullptr;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VkImageObj image(m_device);
+    image.init(&imageInfo);
+    VkImageView view = image.targetView(imageInfo.format);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.imageView = view;
+
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
+    begin_rendering_info.flags = 0u;
+    begin_rendering_info.renderArea.offset.x = 0;
+    begin_rendering_info.renderArea.offset.y = 0;
+    begin_rendering_info.renderArea.extent.width = static_cast<uint32_t>(m_width);
+    begin_rendering_info.renderArea.extent.height = static_cast<uint32_t>(m_height);
+    begin_rendering_info.layerCount = 1u;
+    begin_rendering_info.viewMask = 0x0;
+    begin_rendering_info.colorAttachmentCount = 1u;
+    begin_rendering_info.pColorAttachments = &color_attachment;
+
+    m_commandBuffer->begin();
+
+    {
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        imageMemoryBarrier.image = image.handle();
+        imageMemoryBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        imageMemoryBarrier.subresourceRange.baseMipLevel = 0u;
+        imageMemoryBarrier.subresourceRange.levelCount = 1u;
+        imageMemoryBarrier.subresourceRange.baseArrayLayer = 0u;
+        imageMemoryBarrier.subresourceRange.layerCount = 1u;
+        vkCmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0u, 0u, nullptr, 0u, nullptr, 1u, &imageMemoryBarrier);
+    }
+    vkCmdBeginRenderingKHR(m_commandBuffer->handle(), &begin_rendering_info);
+    vkCmdBindShadersEXT(m_commandBuffer->handle(), 2u, shaderStages, shaders);
+    for (const auto& unusedShader : unusedShaderStages) {
+        VkShaderEXT null_shader = VK_NULL_HANDLE;
+        vkCmdBindShadersEXT(m_commandBuffer->handle(), 1u, &unusedShader, &null_shader);
+    }
+    BindDefaultDynamicStates(vertexBuffer.handle(), false);
+    float pushData[5 * 4] = { 0.2f, 0.4f, 0.6f, 0.8f };
+    memset(&pushData[4], 0, sizeof(pushData) - 4 * sizeof(float));
+    VkPushDataInfoEXT pushDataInfo{ VK_STRUCTURE_TYPE_PUSH_DATA_INFO_EXT, nullptr, 0};
+    pushDataInfo.data.address = pushData;
+    pushDataInfo.data.size = sizeof(pushData);
+    vkCmdPushDataEXT(m_commandBuffer->handle(), &pushDataInfo);
+    vkCmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
+    vkCmdEndRenderingKHR(m_commandBuffer->handle());
+
+    {
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        imageMemoryBarrier.image = image.handle();
+        imageMemoryBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        imageMemoryBarrier.subresourceRange.baseMipLevel = 0u;
+        imageMemoryBarrier.subresourceRange.levelCount = 1u;
+        imageMemoryBarrier.subresourceRange.baseArrayLayer = 0u;
+        imageMemoryBarrier.subresourceRange.layerCount = 1u;
+        vkCmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u, nullptr, 1u, &imageMemoryBarrier);
+    }
+
+    VkBufferImageCopy copyRegion = {};
+    copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    copyRegion.imageSubresource.mipLevel = 0u;
+    copyRegion.imageSubresource.baseArrayLayer = 0u;
+    copyRegion.imageSubresource.layerCount = 1u;
+    copyRegion.imageOffset.x = static_cast<int32_t>(m_width / 2) + 1;
+    copyRegion.imageOffset.y = static_cast<int32_t>(m_height / 2) + 1;
+    copyRegion.imageExtent.width = 1u;
+    copyRegion.imageExtent.height = 1u;
+    copyRegion.imageExtent.depth = 1u;
+
+    vkCmdCopyImageToBuffer(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer.handle(), 1u, &copyRegion);
+
+    m_commandBuffer->end();
+
+    SubmitAndWait();
+
+    float* data;
+    vkMapMemory(m_device->handle(), buffer.memory().handle(), 0u, sizeof(float) * 4u, 0u, (void**)&data);
+    float e = 0.01f;
+    for (uint32_t i = 0; i < 4; ++i) {
+        float expected = 0.2f + i * 0.2f;
+        if (std::fabs(data[i] - expected) > e) {
+            std::string msg = "Wrong pixel value " + std::to_string(data[i]) + ", expected " + std::to_string(0.2f + i * 0.2f);
+            m_errorMonitor->SetError(msg.c_str());
+        }
+    }
+
+    vkUnmapMemory(m_device->handle(), buffer.memory().handle());
+
+    vkDestroyShaderEXT(m_device->handle(), shaders[0], nullptr);
+    vkDestroyShaderEXT(m_device->handle(), shaders[1], nullptr);
+
+    m_errorMonitor->VerifyNotFound();
+}


### PR DESCRIPTION
The VkLayer_khronos_shader_object emulation layer will not render correctly if VK_EXT_descriptor_heap is used. This adds the missing support and a simple test case showing it in action.