### PR TITLE
chore: Cleanup REUSE implementation

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: REUSE Compliance Check
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  reuse-compliance-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: The Khronos Group Inc.
+SPDX-FileCopyrightText: LunarG, Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Build Instructions
 
 1. [Requirements](#requirements)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,6 @@
+<!--
+SPDX-FileCopyrightText: The Khronos Group Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 A reminder that this issue tracker is managed by the Khronos Group. Interactions here should follow the Khronos Code of Conduct ([https://www.khronos.org/developers/code-of-conduct](https://www.khronos.org/developers/code-of-conduct)), which prohibits aggressive or derogatory language. Please keep the discussion friendly and civil.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: The Khronos Group Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # How to Contribute to Vulkan Source Repositories
 
 ## **The Repository**

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/CC-BY-ND-4.0.txt
+++ b/LICENSES/CC-BY-ND-4.0.txt
@@ -1,4 +1,4 @@
-Creative Commons Attribution 4.0 International
+Creative Commons Attribution-NoDerivatives 4.0 International
 
  Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 
@@ -10,33 +10,31 @@ Considerations for licensors: Our public licenses are intended for use by those 
 
 Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
 
-Creative Commons Attribution 4.0 International Public License
+Creative Commons Attribution-NoDerivatives 4.0 International Public License
 
-By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NoDerivatives 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
 Section 1 – Definitions.
 
      a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 
-     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+     b.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
 
-     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+     c.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
 
-     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+     d.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
 
-     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+     e.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
 
-     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+     f.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
 
-     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+     g.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
 
-     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+     h.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
 
-     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+     i.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
 
-     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
-
-     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+     j.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
 
 Section 2 – Scope.
 
@@ -46,7 +44,7 @@ Section 2 – Scope.
 
                A. reproduce and Share the Licensed Material, in whole or in part; and
 
-               B. produce, reproduce, and Share Adapted Material.
+               B. produce and reproduce, but not Share, Adapted Material.
 
           2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
 
@@ -60,9 +58,9 @@ Section 2 – Scope.
 
                B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
 
-          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+          6. No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
 
-b. Other rights.
+     b.	Other rights.
 
           1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
 
@@ -76,35 +74,35 @@ Your exercise of the Licensed Rights is expressly made subject to the following 
 
      a.	Attribution.
 
-          1. If You Share the Licensed Material (including in modified form), You must:
+          1. If You Share the Licensed Material, You must:
 
                A. retain the following if it is supplied by the Licensor with the Licensed Material:
 
                     i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
 
-                    ii. a copyright notice;
+                    ii.	a copyright notice;
 
                     iii. a notice that refers to this Public License;
 
                     iv.	a notice that refers to the disclaimer of warranties;
 
-                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+                    v.	a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
 
                B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
 
                C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
 
-          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+          2. For the avoidance of doubt, You do not have permission under this Public License to Share Adapted Material.
 
-          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+          3. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
 
-          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+          4. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
 
 Section 4 – Sui Generis Database Rights.
 
 Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
 
-     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database, provided You do not Share Adapted Material;
 
      b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: The Khronos Group Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Vulkan Extension Layer (VEL)
 
 ## Introduction

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,19 +3,6 @@ version = 1
 [[annotations]]
 path = [
     ".gitignore",
-    ".clang-format",
-    "layers/vk_layer_settings.txt",
-    "layers/libVkLayer_khronos_timeline_semaphore.map",
-    "layers/libVkLayer_khronos_synchronization2.map",
-    "layers/libVkLayer_khronos_memory_decompression.map",
-    "layers/libVkLayer_khronos_shader_object.map",
-    "layers/json/VkLayer_khronos_memory_decompression.json.in",
-    "layers/json/VkLayer_khronos_synchronization2.json.in",
-    "layers/json/VkLayer_khronos_shader_object.json.in",
-    "layers/json/VkLayer_khronos_timeline_semaphore.json.in",
-    "layers/shader_object/generated/.clang-format",
-    "utils/generated/.clang-format",
-    "utils/log.h",
     ".github/workflows/reuse-compliance.yml",
 ]
 SPDX-FileCopyrightText = "The Khronos Group Inc."
@@ -31,17 +18,40 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
-    "CMakeLists.txt",
-    "layers/CMakeLists.txt",
-    "utils/CMakeLists.txt",
-    "layers/VkLayer_khronos_synchronization2.def",
-    "layers/VkLayer_khronos_timeline_semaphore.def",
+    ".github/dependabot.yml",
+    "docs/shader_object_layer.md",
+    "docs/synchronization2_layer.md",
 ]
-SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc.", "Intel Corporation"]
+SPDX-FileCopyrightText = "LunarG, Inc."
+SPDX-License-Identifier = "CC-BY-ND-4.0"
+
+[[annotations]]
+path = [
+    "scripts/CMakeLists.txt",
+    "layers/vk_layer_settings.txt",
+    "layers/libVkLayer_khronos_synchronization2.map",
+    "layers/json/VkLayer_khronos_synchronization2.json.in",
+]
+SPDX-FileCopyrightText = "LunarG, Inc."
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "scripts/clang-format-diff.py"
+SPDX-FileCopyrightText = "LLVM Project"
+SPDX-License-Identifier = "Apache-2.0 WITH LLVM-exception"
+
+[[annotations]]
+path = [
+    "layers/libVkLayer_khronos_memory_decompression.map",
+    "layers/json/VkLayer_khronos_memory_decompression.json.in",
+]
+SPDX-FileCopyrightText = ["Nvidia Corporation"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
+    "layers/libVkLayer_khronos_timeline_semaphore.map",
+    "layers/json/VkLayer_khronos_timeline_semaphore.json.in",
     "layers/vk_common.h",
     "layers/hash_table.cpp",
     "layers/hash_table.h",
@@ -50,28 +60,62 @@ path = [
     "layers/list.h",
     "layers/timeline_semaphore.c",
 ]
-SPDX-FileCopyrightText = "Intel Corporation"
+SPDX-FileCopyrightText = ["Intel"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
-    "layers/synchronization2.h",
-    "layers/synchronization2.cpp"
-]
-SPDX-FileCopyrightText = ["The Khronos Group Inc.", "LunarG, Inc.", "Advanced Micro Devices, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = [
+    "layers/json/VkLayer_khronos_shader_object.json.in",
+    "layers/libVkLayer_khronos_shader_object.map",
     "layers/vk_api_hash.h",
+    "layers/shader_object/generated/.clang-format",
     "layers/VkLayer_khronos_shader_object.def",
     "layers/shader_object/shader_object_util.h",
     "layers/shader_object/shader_object_structs.h",
     "layers/shader_object/shader_object.cpp",
     "layers/shader_object/generated/**",
     "scripts/shader_object_generator.py",
+    "tests/shader_object_tests.cpp",
+    "tests/shader_object_tests.h",
 ]
 SPDX-FileCopyrightText = "Nintendo"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+    ".clang-format",
+    "utils/generated/.clang-format",
+    "utils/log.h",
+    "utils/allocator.h",
+    "utils/allocator.cpp",
+]
+SPDX-FileCopyrightText = ["LunarG, Inc.", "The Khronos Group Inc."]
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+    "tests/android/**",
+    "tests/CMakeLists.txt",
+    "scripts/github_ci_build_desktop.py",
+    "scripts/android.py",
+    "scripts/check_code_format.py",
+    "scripts/known_good.json",
+    "scripts/shader_object_data.json",
+    ".github/workflows/format.yml",
+    ".github/workflows/ci.yml",
+]
+SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc."]
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+    "CMakeLists.txt",
+    "layers/CMakeLists.txt",
+    "utils/CMakeLists.txt",
+    "layers/VkLayer_khronos_synchronization2.def",
+    "layers/VkLayer_khronos_timeline_semaphore.def",
+]
+SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc.", "Intel Corporation"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
@@ -92,18 +136,10 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
-    "utils/allocator.h",
-    "utils/allocator.cpp",
+    "layers/synchronization2.h",
+    "layers/synchronization2.cpp"
 ]
-SPDX-FileCopyrightText = ["The Khronos Group Inc.", "LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = [
-    "tests/extension_layer_tests.cpp",
-    "tests/extension_layer_tests.h",
-]
-SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG, Inc.", "Google, Inc.", "Nvidia Corporation"]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "LunarG, Inc.", "Advanced Micro Devices, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
@@ -117,49 +153,14 @@ SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = [
-    "tests/shader_object_tests.cpp",
-    "tests/shader_object_tests.h",
-]
-SPDX-FileCopyrightText = ["LunarG, Inc.", "Nintendo"]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = [
-    "tests/android/**",
-    "tests/CMakeLists.txt",
-    "scripts/github_ci_build_desktop.py",
-    "scripts/android.py",
-    "scripts/check_code_format.py",
-    "scripts/known_good.json",
-    "scripts/shader_object_data.json",
-    ".github/workflows/format.yml",
-    ".github/workflows/ci.yml",
-]
-SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/CMakeLists.txt"
-SPDX-FileCopyrightText = "LunarG, Inc."
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/clang-format-diff.py"
-SPDX-FileCopyrightText = "LLVM Project"
-SPDX-License-Identifier = "Apache-2.0 WITH LLVM-exception"
-
-[[annotations]]
 path = "scripts/update_deps.py"
 SPDX-FileCopyrightText = ["The Glslang Authors", "Valve Corporation", "LunarG, Inc.", "RasterGrid Kft."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = [
-    ".github/dependabot.yml",
-    "docs/shader_object_layer.md",
-    "docs/synchronization2_layer.md",
+    "tests/extension_layer_tests.cpp",
+    "tests/extension_layer_tests.h",
 ]
-SPDX-FileCopyrightText = "LunarG, Inc."
-SPDX-License-Identifier = "CC-BY-ND-4.0"
-
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG, Inc.", "Google, Inc.", "Nvidia Corporation"]
+SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,274 +1,165 @@
 version = 1
-SPDX-PackageName = "Vulkan Extension Layer"
-SPDX-PackageSupplier = "The Khronos Group, Inc."
-SPDX-PackageDownloadLocation = "https://github.com/KhronosGroup/Vulkan-ExtensionLayer/"
 
 [[annotations]]
-path = "layers/decompression/**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023-2025 The Khronos Group, Inc.", "2023 NVIDIA CORPORATION & AFFILIATES"]
-SPDX-License-Identifier = "Apache-2.0 OR MIT"
-
-[[annotations]]
-path = "layers/README.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023-2025 The Khronos Group, Inc.", "2023 NVIDIA CORPORATION & AFFILIATES"]
-SPDX-License-Identifier = "CC-BY-4.0"
-
-[[annotations]]
-path = "layers/json/**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023-2025 The Khronos Group, Inc.", "2023 NVIDIA CORPORATION & AFFILIATES"]
+path = [
+    ".gitignore",
+    ".clang-format",
+    "layers/vk_layer_settings.txt",
+    "layers/libVkLayer_khronos_timeline_semaphore.map",
+    "layers/libVkLayer_khronos_synchronization2.map",
+    "layers/libVkLayer_khronos_memory_decompression.map",
+    "layers/libVkLayer_khronos_shader_object.map",
+    "layers/json/VkLayer_khronos_memory_decompression.json.in",
+    "layers/json/VkLayer_khronos_synchronization2.json.in",
+    "layers/json/VkLayer_khronos_shader_object.json.in",
+    "layers/json/VkLayer_khronos_timeline_semaphore.json.in",
+    "layers/shader_object/generated/.clang-format",
+    "utils/generated/.clang-format",
+    "utils/log.h",
+    ".github/workflows/reuse-compliance.yml",
+]
+SPDX-FileCopyrightText = "The Khronos Group Inc."
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "layers/shader_object/**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023-2024 Nintendo"
+path = [
+    "layers/decompression/**",
+    "docs/memory_decompression_layer.md",
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Nvidia Corporation"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["layers/libVkLayer_**", "layers/vk_layer_settings.txt"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The Khronos Group, Inc."
+path = [
+    "CMakeLists.txt",
+    "layers/CMakeLists.txt",
+    "utils/CMakeLists.txt",
+    "layers/VkLayer_khronos_synchronization2.def",
+    "layers/VkLayer_khronos_timeline_semaphore.def",
+]
+SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc.", "Intel Corporation"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "layers/VkLayer_khronos_memory_decompression.def"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 Nvidia Corporation"
-SPDX-License-Identifier = "Apache-2.0 OR MIT"
-
-[[annotations]]
-path = ["layers/VkLayer_khronos_shader_object.def", "layers/vk_api_hash.h"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 Nintendo"
+path = [
+    "layers/vk_common.h",
+    "layers/hash_table.cpp",
+    "layers/hash_table.h",
+    "layers/vk_util.h",
+    "layers/vk_alloc.h",
+    "layers/list.h",
+    "layers/timeline_semaphore.c",
+]
+SPDX-FileCopyrightText = "Intel Corporation"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["layers/VkLayer_khronos_synchronization2.def", "layers/VkLayer_khronos_timeline_semaphore.def"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc.", "2020      Intel Corporation"]
+path = [
+    "layers/synchronization2.h",
+    "layers/synchronization2.cpp"
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "LunarG, Inc.", "Advanced Micro Devices, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["layers/hash_table.**", "layers/list.h", "layers/timeline_semaphore.c", "layers/vk_alloc.h", "layers/vk_common.h", "layers/vk_util.h"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2019 Intel Corporation"
+path = [
+    "layers/vk_api_hash.h",
+    "layers/VkLayer_khronos_shader_object.def",
+    "layers/shader_object/shader_object_util.h",
+    "layers/shader_object/shader_object_structs.h",
+    "layers/shader_object/shader_object.cpp",
+    "layers/shader_object/generated/**",
+    "scripts/shader_object_generator.py",
+]
+SPDX-FileCopyrightText = "Nintendo"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "layers/synchronization2.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2020-2021,2023-2024 The Khronos Group Inc.", "2020-2021,2023-2024 LunarG, Inc.", "2020-2021 Advanced Micro Devices, Inc."]
+path = [
+    "utils/cast_utils.h",
+    "utils/vk_string_utils.h",
+    "tests/test_common.h",
+    "tests/vktestframework.h",
+    "tests/vktestframework.cpp",
+    "tests/vktestbinding.h",
+    "tests/vktestbinding.cpp",
+    "tests/test_environment.h",
+    "tests/test_environment.cpp",
+    "scripts/common_ci.py",
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "layers/synchronization2.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2020-2021,2024 The Khronos Group Inc.", "2020-2021,2024 LunarG, Inc.", "2020-2021,2024 Advanced Micro Devices, Inc."]
+path = [
+    "utils/allocator.h",
+    "utils/allocator.cpp",
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "LunarG, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "layers/CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2014-2024 Valve Corporation", "2014-2024 LunarG, Inc.", "2019      Intel Corporation"]
+path = [
+    "tests/extension_layer_tests.cpp",
+    "tests/extension_layer_tests.h",
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG, Inc.", "Google, Inc.", "Nvidia Corporation"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["**.md", ".clang-format", "utils/generated/.clang-format", ".github/**.yml", ".gitignore", "tests/android/README.md"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The Khronos Group, Inc."
-SPDX-License-Identifier = "CC-BY-4.0"
-
-[[annotations]]
-path = "CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2014-2025 Valve Corporation", "2014-2025 LunarG, Inc.", "2019      Intel Corporation."]
+path = [
+    "tests/vkrenderframework.h",
+    "tests/vkrenderframework.cpp",
+    "tests/synchronization2_tests.cpp",
+    "tests/synchronization2_tests.h",
+]
+SPDX-FileCopyrightText = ["The Khronos Group Inc.", "Valve Corporation", "LunarG, Inc.", "Google, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["utils/allocator.cpp", "utils/allocator.h"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2020-2021 The Khronos Group Inc.", "2020-2021 LunarG, Inc."]
+path = [
+    "tests/shader_object_tests.cpp",
+    "tests/shader_object_tests.h",
+]
+SPDX-FileCopyrightText = ["LunarG, Inc.", "Nintendo"]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "utils/log.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2021 The Khronos Group Inc."
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "utils/vk_string_utils.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2017, 2019-2020 The Khronos Group Inc.", "2015-2017, 2019-2020 Valve Corporation", "2015-2017, 2019-2020 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "utils/cast_utils.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2019 The Khronos Group Inc.", "2019-2023 Valve Corporation", "2019-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "utils/CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2014-2024 Valve Corporation", "2014-2024 LunarG, Inc.", "2019      Intel Corporation"]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/clang-format-diff.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The Khronos Group Inc."
-SPDX-License-Identifier = "Apache-2.0 WITH LLVM-exception"
-
-[[annotations]]
-path = "scripts/**.json"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The Khronos Group Inc."
+path = [
+    "tests/android/**",
+    "tests/CMakeLists.txt",
+    "scripts/github_ci_build_desktop.py",
+    "scripts/android.py",
+    "scripts/check_code_format.py",
+    "scripts/known_good.json",
+    "scripts/shader_object_data.json",
+    ".github/workflows/format.yml",
+    ".github/workflows/ci.yml",
+]
+SPDX-FileCopyrightText = ["Valve Corporation", "LunarG, Inc."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "scripts/CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 LunarG, Inc."
+SPDX-FileCopyrightText = "LunarG, Inc."
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "scripts/android.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023 Valve Corporation", "2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/check_code_format.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2020-2023 Valve Corporation", "2020-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/common_ci.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2017, 2019-2024 The Khronos Group Inc.", "2015-2017, 2019-2024 Valve Corporation", "2015-2017, 2019-2024 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/github_ci_build_desktop.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2020-2021 Valve Corporation", "2020-2021 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "scripts/shader_object_generator.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023-2024 Nintendo"
-SPDX-License-Identifier = "Apache-2.0"
+path = "scripts/clang-format-diff.py"
+SPDX-FileCopyrightText = "LLVM Project"
+SPDX-License-Identifier = "Apache-2.0 WITH LLVM-exception"
 
 [[annotations]]
 path = "scripts/update_deps.py"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2017 The Glslang Authors. All rights reserved.", "2018-2023 Valve Corporation", "2018-2023 LunarG, Inc.", "2023-2023 RasterGrid Kft."]
+SPDX-FileCopyrightText = ["The Glslang Authors", "Valve Corporation", "LunarG, Inc.", "RasterGrid Kft."]
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["tests/android/android.map", "tests/android/AndroidManifest.xml"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The Khronos Group, Inc."
-SPDX-License-Identifier = "CC-BY-4.0"
+path = [
+    ".github/dependabot.yml",
+    "docs/shader_object_layer.md",
+    "docs/synchronization2_layer.md",
+]
+SPDX-FileCopyrightText = "LunarG, Inc."
+SPDX-License-Identifier = "CC-BY-ND-4.0"
 
-[[annotations]]
-path = "tests/CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2014-2024 Valve Corporation", "2014-2024 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/android/CMakeLists.txt"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023 Valve Corporation", "2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/decompression**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023 The Khronos Group Inc.", "2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/extension_layer_tests.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2022 The Khronos Group Inc.", "2015-2024 Valve Corporation", "2015-2024 LunarG, Inc.", "2015-2022 Google, Inc.", "2015-2023 Nvidia Corporation."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/extension_layer_tests.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2022 The Khronos Group Inc.", "2015-2024 Valve Corporation", "2015-2024 LunarG, Inc.", "2015-2022 Google, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/shader_object_tests.**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2023-2024 LunarG, Inc.", "2023-2024 Nintendo"]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/synchronization2_tests.**"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2024 The Khronos Group Inc.", "2015-2024 Valve Corporation", "2015-2024 LunarG, Inc.", "2015-2022 Google, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/test_common.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/test_environment.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2021 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/test_environment.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vkrenderframework.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2022 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc.", "2015-2022 Google, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vkrenderframework.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vktestbinding.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2022 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vktestbinding.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2016, 2020-2023 The Khronos Group Inc.", "2015-2016, 2020-2023 Valve Corporation", "2015-2016, 2020-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vktestframework.cpp"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2024 The Khronos Group Inc.", "2015-2024 Valve Corporation", "2015-2024 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/vktestframework.h"
-precedence = "aggregate"
-SPDX-FileCopyrightText = ["2015-2023 The Khronos Group Inc.", "2015-2023 Valve Corporation", "2015-2023 LunarG, Inc."]
-SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
- cleanup REUSE.toml - fix one incorrect copyright assignment
- add GitHub reuse Action workflow
- add LICENSE.txt

Currently for the following files I have set Khronos Group as the copyright holder. I am unsure if this is correct. Before merging, can this be verified? 

```
    "layers/vk_layer_settings.txt",
    "layers/libVkLayer_khronos_timeline_semaphore.map",
    "layers/libVkLayer_khronos_synchronization2.map",
    "layers/libVkLayer_khronos_memory_decompression.map",
    "layers/libVkLayer_khronos_shader_object.map",
    "layers/json/VkLayer_khronos_memory_decompression.json.in",
    "layers/json/VkLayer_khronos_synchronization2.json.in",
    "layers/json/VkLayer_khronos_shader_object.json.in",
    "layers/json/VkLayer_khronos_timeline_semaphore.json.in",
    "layers/shader_object/generated/.clang-format",
```