### PR TITLE
layers: Fix shader object embedded samplers

### DIFF
--- a/layers/shader_object/shader_object.cpp
+++ b/layers/shader_object/shader_object.cpp
@@ -542,6 +542,8 @@ VkResult Shader::Create(DeviceData const& deviceData, VkShaderCreateInfoEXT cons
                     }
                     pInNext = pInNext->pNext;
                 }
+
+                *pEmbeddedSampler = pOutEmbeddedSampler;
             }
         };
 


### PR DESCRIPTION
The pointers should point to memory allocated by the layer, the original pointers might be out of scope by the time pipelines are created